### PR TITLE
Implement digit agent hierarchy and vote aggregation core scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,19 +21,20 @@ LDFLAGS := $(OPENSSL_LIBS) -lm
 SRC := backend/src
 BIN_DIR := bin
 BINS := $(BIN_DIR)/kolibri_run $(BIN_DIR)/kolibri_verify $(BIN_DIR)/kolibri_replay
+COMMON_OBJS := $(SRC)/digit_agents.c $(SRC)/vote_aggregate.c
 
 all: $(BIN_DIR) $(BINS)
 
 $(BIN_DIR):
 	@mkdir -p $(BIN_DIR)
 
-$(BIN_DIR)/kolibri_run: $(SRC)/main_run.c $(SRC)/core.c $(SRC)/dsl.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c
+$(BIN_DIR)/kolibri_run: $(SRC)/main_run.c $(SRC)/core.c $(SRC)/dsl.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c $(COMMON_OBJS)
 	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
 
 $(BIN_DIR)/kolibri_verify: $(SRC)/main_verify.c $(SRC)/dsl.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c
 	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/kolibri_replay: $(SRC)/main_replay.c $(SRC)/core.c $(SRC)/dsl.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c
+$(BIN_DIR)/kolibri_replay: $(SRC)/main_replay.c $(SRC)/core.c $(SRC)/dsl.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c $(COMMON_OBJS)
 	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
 
 clean:

--- a/backend/include/digit_agents.h
+++ b/backend/include/digit_agents.h
@@ -3,25 +3,17 @@
 
 #include "common.h"
 
-typedef struct DigitAgent {
-    double weight;
-    uint64_t seed;
-    struct DigitAgent* sub[10];
-} DigitAgent;
-
 typedef struct {
-    DigitAgent* root[10];
-    int depth_max;
-} DigitField;
+    int step;               // current step index (>= 1)
+    uint64_t seed;          // deterministic seed shared across agents
+    double quorum;          // quorum threshold supplied by the core
+} AgentContext;
 
 typedef struct {
     double vote[10];
-    double temperature;
 } VoteState;
 
-bool digit_field_init(DigitField* f, int depth_max, uint64_t seed);
-void digit_field_free(DigitField* f);
-void digit_tick(DigitField* f, const double external[10]);
-void digit_aggregate(const DigitField* f, VoteState* out);
+double agent_vote(const AgentContext* ctx, int agent_id);
+void digit_votes(const AgentContext* ctx, VoteState* out);
 
 #endif

--- a/backend/include/digit_agents.h
+++ b/backend/include/digit_agents.h
@@ -1,0 +1,27 @@
+#ifndef KOLIBRI_DIGIT_AGENTS_H
+#define KOLIBRI_DIGIT_AGENTS_H
+
+#include "common.h"
+
+typedef struct DigitAgent {
+    double weight;
+    uint64_t seed;
+    struct DigitAgent* sub[10];
+} DigitAgent;
+
+typedef struct {
+    DigitAgent* root[10];
+    int depth_max;
+} DigitField;
+
+typedef struct {
+    double vote[10];
+    double temperature;
+} VoteState;
+
+bool digit_field_init(DigitField* f, int depth_max, uint64_t seed);
+void digit_field_free(DigitField* f);
+void digit_tick(DigitField* f, const double external[10]);
+void digit_aggregate(const DigitField* f, VoteState* out);
+
+#endif

--- a/backend/include/digit_agents.h
+++ b/backend/include/digit_agents.h
@@ -2,18 +2,27 @@
 #define KOLIBRI_DIGIT_AGENTS_H
 
 #include "common.h"
+#include <stdbool.h>
+
+typedef struct DigitAgent {
+    double weight;
+    uint64_t seed;
+    struct DigitAgent* sub[10];
+} DigitAgent;
 
 typedef struct {
-    int step;               // current step index (>= 1)
-    uint64_t seed;          // deterministic seed shared across agents
-    double quorum;          // quorum threshold supplied by the core
-} AgentContext;
+    DigitAgent* root[10];
+    int depth_max;
+} DigitField;
 
 typedef struct {
     double vote[10];
+    double temperature;
 } VoteState;
 
-double agent_vote(const AgentContext* ctx, int agent_id);
-void digit_votes(const AgentContext* ctx, VoteState* out);
+bool digit_field_init(DigitField* field, int depth_max, uint64_t seed);
+void digit_field_free(DigitField* field);
+void digit_tick(DigitField* field);
+void digit_aggregate(const DigitField* field, VoteState* out);
 
 #endif

--- a/backend/include/vote_aggregate.h
+++ b/backend/include/vote_aggregate.h
@@ -4,9 +4,8 @@
 #include "digit_agents.h"
 
 typedef struct {
-    double depth_decay;   // blending against neutral prior (0..1)
-    double quorum;        // zero-out threshold
-    double temperature;   // softening factor (0..1)
+    double depth_decay;   // contribution from deeper hierarchy layers (0..1)
+    double quorum;        // activation threshold
 } VotePolicy;
 
 void vote_apply_policy(VoteState* state, const VotePolicy* policy);

--- a/backend/include/vote_aggregate.h
+++ b/backend/include/vote_aggregate.h
@@ -1,0 +1,13 @@
+#ifndef KOLIBRI_VOTE_AGGREGATE_H
+#define KOLIBRI_VOTE_AGGREGATE_H
+
+#include "digit_agents.h"
+
+typedef struct {
+    double depth_decay;
+    double quorum;
+} VotePolicy;
+
+void vote_apply_policy(VoteState* state, const VotePolicy* policy);
+
+#endif

--- a/backend/include/vote_aggregate.h
+++ b/backend/include/vote_aggregate.h
@@ -4,8 +4,9 @@
 #include "digit_agents.h"
 
 typedef struct {
-    double depth_decay;
-    double quorum;
+    double depth_decay;   // blending against neutral prior (0..1)
+    double quorum;        // zero-out threshold
+    double temperature;   // softening factor (0..1)
 } VotePolicy;
 
 void vote_apply_policy(VoteState* state, const VotePolicy* policy);

--- a/backend/src/core.c
+++ b/backend/src/core.c
@@ -1,6 +1,8 @@
 #include "core.h"
 #include "dsl.h"
 #include "chainio.h"
+#include "digit_agents.h"
+#include "vote_aggregate.h"
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -20,16 +22,31 @@ static double eff_of(const Formula* f){
     mse/=n; return 1.0/(1.0+mse);
 }
 
-static Formula* propose(const double vote[10], uint64_t seed){
+static DigitField g_field;
+static bool g_field_ready = false;
+
+static void cleanup_digit_field(void) {
+    if (g_field_ready) {
+        digit_field_free(&g_field);
+        g_field_ready = false;
+    }
+}
+
+static Formula* propose_formula(const VoteState* state, uint64_t seed){
     uint64_t s=seed;
     int choice=(int)floor(prng01(&s)*5.0);
     switch(choice){
-        case 0: return f_add(f_x(), f_sin(f_x()));
-        case 1: return f_sin(f_mul(f_const(0.1 + 2.9*vote[2]), f_x()));
-        case 2: return f_add(f_mul(f_const(-2+4*vote[0]), f_sin(f_x())),
-                             f_mul(f_const(-1+2*vote[1]), f_x()));
-        case 3: return f_const(-1+2*vote[3]);
-        default: return f_const(-2+4*vote[4]);
+        case 0:
+            return f_add(f_x(), f_sin(f_x()));
+        case 1:
+            return f_sin(f_mul(f_const(0.1 + 2.9*state->vote[2]), f_x()));
+        case 2:
+            return f_add(f_mul(f_const(-2+4*state->vote[0]), f_sin(f_x())),
+                         f_mul(f_const(-1+2*state->vote[1]), f_x()));
+        case 3:
+            return f_const(-1+2*state->vote[3]);
+        default:
+            return f_const(-2+4*state->vote[4]);
     }
 }
 
@@ -38,15 +55,29 @@ bool kolibri_step(const kolibri_config_t* cfg, int step, const char* prev_hash,
     memset(out,0,sizeof(*out));
     out->step=step; out->parent=step-1; out->seed=cfg->seed^((uint64_t)step);
 
-    // simple "votes": pseudo weights
-    uint64_t s=out->seed;
-    for(int i=0;i<10;i++){
-        double r = prng01(&s);
-        out->votes[i] = 0.5 + 0.5*cos(step*0.17 + r*6.28318);
-        if(out->votes[i] < cfg->quorum) out->votes[i]=0.0;
+    if(!g_field_ready){
+        if(!digit_field_init(&g_field, cfg->depth_max, cfg->seed)){
+            return false;
+        }
+        g_field_ready = true;
+        atexit(cleanup_digit_field);
     }
 
-    Formula* f = propose(out->votes, out->seed);
+    digit_tick(&g_field, NULL);
+
+    VoteState vote_state;
+    memset(&vote_state, 0, sizeof(vote_state));
+    digit_aggregate(&g_field, &vote_state);
+    vote_state.temperature = cfg->temperature;
+
+    VotePolicy policy = { cfg->depth_decay, cfg->quorum };
+    vote_apply_policy(&vote_state, &policy);
+
+    for (int i = 0; i < 10; ++i) {
+        out->votes[i] = vote_state.vote[i];
+    }
+
+    Formula* f = propose_formula(&vote_state, out->seed);
     out->eff = eff_of(f);
     out->compl = (double)f_complexity(f);
     f_render(f, out->formula, sizeof(out->formula));

--- a/backend/src/digit_agents.c
+++ b/backend/src/digit_agents.c
@@ -1,0 +1,180 @@
+#include "digit_agents.h"
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+static uint64_t next_u64(uint64_t* state) {
+    uint64_t x = *state;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    *state = x;
+    return x * UINT64_C(2685821657736338717);
+}
+
+static double prng01(uint64_t* state) {
+    return (next_u64(state) >> 11) * (1.0 / 9007199254740992.0);
+}
+
+static void free_agent(DigitAgent* a);
+
+static DigitAgent* create_agent(int depth, int depth_max, uint64_t* seed) {
+    DigitAgent* a = (DigitAgent*)calloc(1, sizeof(DigitAgent));
+    if (!a) {
+        return NULL;
+    }
+    uint64_t local = *seed + (uint64_t)depth * UINT64_C(0x9E3779B185EBCA87);
+    a->seed = next_u64(&local);
+    double noise = prng01(&a->seed);
+    a->weight = 0.45 + 0.1 * (double)depth + 0.45 * noise;
+    if (a->weight > 1.0) {
+        a->weight = 1.0;
+    }
+    if (a->weight < 0.0) {
+        a->weight = 0.0;
+    }
+
+    if (depth < depth_max) {
+        for (int i = 0; i < 10; ++i) {
+            uint64_t child_seed = a->seed ^ (uint64_t)i * UINT64_C(0xC2B2AE3D27D4EB4F);
+            a->sub[i] = create_agent(depth + 1, depth_max, &child_seed);
+            if (!a->sub[i] && depth + 1 <= depth_max) {
+                // allocation failed, clean up and abort
+                for (int j = 0; j < i; ++j) {
+                    if (a->sub[j]) {
+                        free_agent(a->sub[j]);
+                        a->sub[j] = NULL;
+                    }
+                }
+                free(a);
+                return NULL;
+            }
+        }
+    }
+    return a;
+}
+
+static void free_agent(DigitAgent* a) {
+    if (!a) {
+        return;
+    }
+    for (int i = 0; i < 10; ++i) {
+        free_agent(a->sub[i]);
+    }
+    free(a);
+}
+
+static void tick_agent(DigitAgent* a, double signal, int depth) {
+    if (!a) {
+        return;
+    }
+    uint64_t state = a->seed;
+    double noise = prng01(&state);
+    a->seed = state;
+
+    double target = noise;
+    if (signal >= 0.0) {
+        double mix = 0.6 + 0.1 * fmin((double)depth, 4.0);
+        if (mix > 0.95) {
+            mix = 0.95;
+        }
+        target = mix * signal + (1.0 - mix) * noise;
+    }
+
+    double inertia = 0.65 + 0.05 * (double)(depth > 0 ? 1 : 0);
+    if (inertia > 0.95) {
+        inertia = 0.95;
+    }
+    a->weight = inertia * a->weight + (1.0 - inertia) * target;
+    if (a->weight < 0.0) {
+        a->weight = 0.0;
+    } else if (a->weight > 1.0) {
+        a->weight = 1.0;
+    }
+
+    for (int i = 0; i < 10; ++i) {
+        tick_agent(a->sub[i], signal, depth + 1);
+    }
+}
+
+static void accumulate(const DigitAgent* a, int depth, double* sum, double* norm) {
+    if (!a) {
+        return;
+    }
+    double factor = 1.0 / (double)(depth + 1);
+    *sum += a->weight * factor;
+    *norm += factor;
+    for (int i = 0; i < 10; ++i) {
+        accumulate(a->sub[i], depth + 1, sum, norm);
+    }
+}
+
+bool digit_field_init(DigitField* f, int depth_max, uint64_t seed) {
+    if (!f || depth_max < 0) {
+        return false;
+    }
+    memset(f, 0, sizeof(*f));
+    f->depth_max = depth_max;
+    for (int i = 0; i < 10; ++i) {
+        uint64_t local_seed = seed ^ ((uint64_t)i * UINT64_C(0xA0761D6478BD642F));
+        f->root[i] = create_agent(0, depth_max, &local_seed);
+        if (!f->root[i]) {
+            digit_field_free(f);
+            return false;
+        }
+    }
+    return true;
+}
+
+void digit_field_free(DigitField* f) {
+    if (!f) {
+        return;
+    }
+    for (int i = 0; i < 10; ++i) {
+        free_agent(f->root[i]);
+        f->root[i] = NULL;
+    }
+    f->depth_max = 0;
+}
+
+void digit_tick(DigitField* f, const double external[10]) {
+    if (!f) {
+        return;
+    }
+    for (int i = 0; i < 10; ++i) {
+        double signal = external ? external[i] : -1.0;
+        if (signal > 1.0) {
+            signal = 1.0;
+        }
+        if (signal < 0.0 && external) {
+            signal = 0.0;
+        }
+        tick_agent(f->root[i], signal, 0);
+    }
+}
+
+void digit_aggregate(const DigitField* f, VoteState* out) {
+    if (!f || !out) {
+        return;
+    }
+    for (int i = 0; i < 10; ++i) {
+        out->vote[i] = 0.0;
+    }
+    double total = 0.0;
+    for (int i = 0; i < 10; ++i) {
+        double sum = 0.0;
+        double norm = 0.0;
+        accumulate(f->root[i], 0, &sum, &norm);
+        if (norm > 0.0) {
+            out->vote[i] = sum / norm;
+        } else {
+            out->vote[i] = 0.0;
+        }
+        total += out->vote[i];
+    }
+    if (total > 0.0) {
+        for (int i = 0; i < 10; ++i) {
+            out->vote[i] /= total;
+        }
+    }
+}

--- a/backend/src/digit_agents.c
+++ b/backend/src/digit_agents.c
@@ -1,180 +1,76 @@
 #include "digit_agents.h"
-#include <stdlib.h>
-#include <string.h>
 #include <math.h>
+#include <string.h>
 
-static uint64_t next_u64(uint64_t* state) {
-    uint64_t x = *state;
-    x ^= x >> 12;
-    x ^= x << 25;
-    x ^= x >> 27;
-    *state = x;
-    return x * UINT64_C(2685821657736338717);
+static double clamp01(double v) {
+    if (v < 0.0) {
+        return 0.0;
+    }
+    if (v > 1.0) {
+        return 1.0;
+    }
+    return v;
 }
 
-static double prng01(uint64_t* state) {
-    return (next_u64(state) >> 11) * (1.0 / 9007199254740992.0);
+static uint64_t splitmix64(uint64_t x) {
+    x += UINT64_C(0x9E3779B97F4A7C15);
+    x = (x ^ (x >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94D049BB133111EB);
+    return x ^ (x >> 31);
 }
 
-static void free_agent(DigitAgent* a);
-
-static DigitAgent* create_agent(int depth, int depth_max, uint64_t* seed) {
-    DigitAgent* a = (DigitAgent*)calloc(1, sizeof(DigitAgent));
-    if (!a) {
-        return NULL;
-    }
-    uint64_t local = *seed + (uint64_t)depth * UINT64_C(0x9E3779B185EBCA87);
-    a->seed = next_u64(&local);
-    double noise = prng01(&a->seed);
-    a->weight = 0.45 + 0.1 * (double)depth + 0.45 * noise;
-    if (a->weight > 1.0) {
-        a->weight = 1.0;
-    }
-    if (a->weight < 0.0) {
-        a->weight = 0.0;
-    }
-
-    if (depth < depth_max) {
-        for (int i = 0; i < 10; ++i) {
-            uint64_t child_seed = a->seed ^ (uint64_t)i * UINT64_C(0xC2B2AE3D27D4EB4F);
-            a->sub[i] = create_agent(depth + 1, depth_max, &child_seed);
-            if (!a->sub[i] && depth + 1 <= depth_max) {
-                // allocation failed, clean up and abort
-                for (int j = 0; j < i; ++j) {
-                    if (a->sub[j]) {
-                        free_agent(a->sub[j]);
-                        a->sub[j] = NULL;
-                    }
-                }
-                free(a);
-                return NULL;
-            }
-        }
-    }
-    return a;
+static double unit_from_u64(uint64_t x) {
+    return (double)(x >> 11) * (1.0 / 9007199254740992.0);
 }
 
-static void free_agent(DigitAgent* a) {
-    if (!a) {
+static double base_pattern(int agent_id, int step) {
+    const double harmonics[10] = {
+        0.73, 1.17, 0.93, 1.41, 0.66,
+        1.07, 0.81, 1.23, 0.58, 1.37
+    };
+    const double offsets[10] = {
+        0.0, 0.35, 0.62, 0.18, 0.47,
+        0.73, 0.28, 0.92, 0.11, 0.56
+    };
+    double freq = harmonics[agent_id];
+    double shift = offsets[agent_id];
+    double phase = (double)step * freq + shift;
+    double wave = sin(phase);
+    return 0.5 + 0.5 * wave;
+}
+
+double agent_vote(const AgentContext* ctx, int agent_id) {
+    if (!ctx || agent_id < 0 || agent_id >= 10) {
+        return 0.0;
+    }
+
+    uint64_t seed = ctx->seed;
+    seed ^= (uint64_t)(ctx->step + 1) * UINT64_C(0xA0761D6478BD642F);
+    seed ^= (uint64_t)(agent_id + 1) * UINT64_C(0xE7037ED1A0B428DB);
+    uint64_t noise_src = splitmix64(seed);
+    double noise = unit_from_u64(noise_src);
+
+    double pattern = base_pattern(agent_id, ctx->step);
+    double influence = 0.65 * pattern + 0.35 * noise;
+
+    if (ctx->quorum > 0.0) {
+        double guard = clamp01(ctx->quorum * 0.5);
+        influence = guard + (1.0 - guard) * influence;
+    }
+
+    return clamp01(influence);
+}
+
+void digit_votes(const AgentContext* ctx, VoteState* out) {
+    if (!out) {
+        return;
+    }
+    memset(out->vote, 0, sizeof(out->vote));
+    if (!ctx) {
         return;
     }
     for (int i = 0; i < 10; ++i) {
-        free_agent(a->sub[i]);
-    }
-    free(a);
-}
-
-static void tick_agent(DigitAgent* a, double signal, int depth) {
-    if (!a) {
-        return;
-    }
-    uint64_t state = a->seed;
-    double noise = prng01(&state);
-    a->seed = state;
-
-    double target = noise;
-    if (signal >= 0.0) {
-        double mix = 0.6 + 0.1 * fmin((double)depth, 4.0);
-        if (mix > 0.95) {
-            mix = 0.95;
-        }
-        target = mix * signal + (1.0 - mix) * noise;
-    }
-
-    double inertia = 0.65 + 0.05 * (double)(depth > 0 ? 1 : 0);
-    if (inertia > 0.95) {
-        inertia = 0.95;
-    }
-    a->weight = inertia * a->weight + (1.0 - inertia) * target;
-    if (a->weight < 0.0) {
-        a->weight = 0.0;
-    } else if (a->weight > 1.0) {
-        a->weight = 1.0;
-    }
-
-    for (int i = 0; i < 10; ++i) {
-        tick_agent(a->sub[i], signal, depth + 1);
+        out->vote[i] = agent_vote(ctx, i);
     }
 }
 
-static void accumulate(const DigitAgent* a, int depth, double* sum, double* norm) {
-    if (!a) {
-        return;
-    }
-    double factor = 1.0 / (double)(depth + 1);
-    *sum += a->weight * factor;
-    *norm += factor;
-    for (int i = 0; i < 10; ++i) {
-        accumulate(a->sub[i], depth + 1, sum, norm);
-    }
-}
-
-bool digit_field_init(DigitField* f, int depth_max, uint64_t seed) {
-    if (!f || depth_max < 0) {
-        return false;
-    }
-    memset(f, 0, sizeof(*f));
-    f->depth_max = depth_max;
-    for (int i = 0; i < 10; ++i) {
-        uint64_t local_seed = seed ^ ((uint64_t)i * UINT64_C(0xA0761D6478BD642F));
-        f->root[i] = create_agent(0, depth_max, &local_seed);
-        if (!f->root[i]) {
-            digit_field_free(f);
-            return false;
-        }
-    }
-    return true;
-}
-
-void digit_field_free(DigitField* f) {
-    if (!f) {
-        return;
-    }
-    for (int i = 0; i < 10; ++i) {
-        free_agent(f->root[i]);
-        f->root[i] = NULL;
-    }
-    f->depth_max = 0;
-}
-
-void digit_tick(DigitField* f, const double external[10]) {
-    if (!f) {
-        return;
-    }
-    for (int i = 0; i < 10; ++i) {
-        double signal = external ? external[i] : -1.0;
-        if (signal > 1.0) {
-            signal = 1.0;
-        }
-        if (signal < 0.0 && external) {
-            signal = 0.0;
-        }
-        tick_agent(f->root[i], signal, 0);
-    }
-}
-
-void digit_aggregate(const DigitField* f, VoteState* out) {
-    if (!f || !out) {
-        return;
-    }
-    for (int i = 0; i < 10; ++i) {
-        out->vote[i] = 0.0;
-    }
-    double total = 0.0;
-    for (int i = 0; i < 10; ++i) {
-        double sum = 0.0;
-        double norm = 0.0;
-        accumulate(f->root[i], 0, &sum, &norm);
-        if (norm > 0.0) {
-            out->vote[i] = sum / norm;
-        } else {
-            out->vote[i] = 0.0;
-        }
-        total += out->vote[i];
-    }
-    if (total > 0.0) {
-        for (int i = 0; i < 10; ++i) {
-            out->vote[i] /= total;
-        }
-    }
-}

--- a/backend/src/vote_aggregate.c
+++ b/backend/src/vote_aggregate.c
@@ -1,0 +1,74 @@
+#include "vote_aggregate.h"
+#include <math.h>
+#include <string.h>
+
+static double clamp01(double v) {
+    if (v < 0.0) {
+        return 0.0;
+    }
+    if (v > 1.0) {
+        return 1.0;
+    }
+    return v;
+}
+
+void vote_apply_policy(VoteState* state, const VotePolicy* policy) {
+    if (!state || !policy) {
+        return;
+    }
+
+    double decay = policy->depth_decay;
+    if (decay < 0.0) {
+        decay = 0.0;
+    } else if (decay > 1.0) {
+        decay = 1.0;
+    }
+    double quorum = policy->quorum;
+    if (quorum < 0.0) {
+        quorum = 0.0;
+    } else if (quorum > 1.0) {
+        quorum = 1.0;
+    }
+
+    const double uniform = 1.0 / 10.0;
+    double adjusted[10];
+    for (int i = 0; i < 10; ++i) {
+        double v = clamp01(state->vote[i]);
+        v = decay * v + (1.0 - decay) * uniform;
+        if (v < quorum) {
+            v = 0.0;
+        }
+        adjusted[i] = v;
+    }
+
+    double temperature = state->temperature;
+    if (temperature <= 0.0) {
+        temperature = 1e-3;
+    }
+
+    double max_v = adjusted[0];
+    for (int i = 1; i < 10; ++i) {
+        if (adjusted[i] > max_v) {
+            max_v = adjusted[i];
+        }
+    }
+
+    double sum = 0.0;
+    for (int i = 0; i < 10; ++i) {
+        double scaled = (adjusted[i] - max_v) / temperature;
+        double e = exp(scaled);
+        adjusted[i] = e;
+        sum += e;
+    }
+
+    if (sum <= 0.0) {
+        for (int i = 0; i < 10; ++i) {
+            state->vote[i] = uniform;
+        }
+        return;
+    }
+
+    for (int i = 0; i < 10; ++i) {
+        state->vote[i] = adjusted[i] / sum;
+    }
+}


### PR DESCRIPTION
## Summary
- add digit agent and vote policy headers/implementations that build a deterministic fractal hierarchy and aggregate votes
- wire the vote field and policy into the Kolibri core loop so proposal selection is driven by the vote state
- update the build to compile the new modules alongside the existing binaries

## Testing
- make


------
https://chatgpt.com/codex/tasks/task_e_68cf4bf061648323a56ef929f3dd1057