### PR TITLE
Implement sprint 1 enhancements

### DIFF
--- a/backend/include/chainio.h
+++ b/backend/include/chainio.h
@@ -2,6 +2,8 @@
 #define KOLIBRI_CHAINIO_H
 #include "reason.h"
 #include <stdbool.h>
+#include <stdio.h>
 bool chain_append(const char* path, const ReasonBlock* b);
 bool chain_load(const char* path, ReasonBlock** out_arr, size_t* out_n);
+bool chain_verify(const char* path, FILE* out);
 #endif

--- a/backend/include/dsl.h
+++ b/backend/include/dsl.h
@@ -2,26 +2,58 @@
 #define KOLIBRI_DSL_H
 #include "common.h"
 
-typedef enum { F_CONST, F_VAR_X, F_ADD, F_SUB, F_MUL, F_DIV, F_SIN } NodeType;
+typedef enum {
+    F_CONST,
+    F_PARAM,
+    F_VAR_X,
+    F_ADD,
+    F_SUB,
+    F_MUL,
+    F_DIV,
+    F_MIN,
+    F_MAX,
+    F_SIN,
+    F_COS,
+    F_EXP,
+    F_LOG,
+    F_POW,
+    F_TANH,
+    F_SIGMOID,
+    F_ABS
+} NodeType;
 
 typedef struct Formula {
     NodeType t;
     double v;
+    int param_index;
     struct Formula* a;
     struct Formula* b;
 } Formula;
 
 Formula* f_const(double v);
+Formula* f_param(int idx);
 Formula* f_x();
 Formula* f_add(Formula* a, Formula* b);
 Formula* f_sub(Formula* a, Formula* b);
 Formula* f_mul(Formula* a, Formula* b);
 Formula* f_div(Formula* a, Formula* b);
+Formula* f_min(Formula* a, Formula* b);
+Formula* f_max(Formula* a, Formula* b);
 Formula* f_sin(Formula* a);
+Formula* f_cos(Formula* a);
+Formula* f_exp(Formula* a);
+Formula* f_log(Formula* a);
+Formula* f_pow(Formula* a, Formula* b);
+Formula* f_tanh(Formula* a);
+Formula* f_sigmoid(Formula* a);
+Formula* f_abs(Formula* a);
 
-double f_eval(const Formula* f, double x);
+double f_eval(const Formula* f, const double* params, size_t param_count, double x);
+double f_eval_grad(const Formula* f, const double* params, size_t param_count,
+                   double x, double* grad_out);
 int    f_complexity(const Formula* f);
 int    f_render(const Formula* f, char* out, size_t n);
+int    f_max_param_index(const Formula* f);
 void   f_free(Formula* f);
 
 #endif

--- a/backend/include/reason.h
+++ b/backend/include/reason.h
@@ -5,15 +5,24 @@
 typedef struct {
     uint64_t step, parent, seed;
     double votes[10];
+    double vote_softmax;
+    double vote_median;
     char formula[256];
+    int param_count;
+    double params[8];
+    double bench_eff[10];
+    char memory[256];
+    char fmt[16];
     double eff, compl;
     char prev[65];
+    char merkle[65];
     char hash[65];
     char hmac[65];
 } ReasonBlock;
 
 /* Build canonical JSON payload (without hash/hmac), into buf.
-   Order: step,parent,seed,formula,eff,compl,prev,votes (10)
+   Order: step,parent,seed,fmt,formula,param_count,params,eff,compl,prev,votes (10),
+          vote_softmax,vote_median,bench (10),memory,merkle
    Floats: %.17g
    No spaces anywhere.
    Example:

--- a/backend/src/config.c
+++ b/backend/src/config.c
@@ -18,7 +18,10 @@ bool kolibri_load_config(kolibri_config_t* c, const char* json_path){
     if(!f) return true;
     fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
     char* buf=(char*)malloc(n+1); if(!buf){ fclose(f); return true; }
-    fread(buf,1,n,f); buf[n]=0; fclose(f);
+    size_t readn=fread(buf,1,(size_t)n,f);
+    fclose(f);
+    if(readn!=(size_t)n){ free(buf); return true; }
+    buf[n]=0;
     char* p=buf;
     #define GETI(k,dst) do{ char* q=strstr(p,k); if(q){ q=strchr(q,':'); if(q){ dst=atoi(q+1);} } }while(0)
     #define GETD(k,dst) do{ char* q=strstr(p,k); if(q){ q=strchr(q,':'); if(q){ dst=atof(q+1);} } }while(0)

--- a/backend/src/core.c
+++ b/backend/src/core.c
@@ -4,71 +4,374 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#ifdef __SSE2__
+#include <immintrin.h>
+#endif
+#include <openssl/sha.h>
+#include <openssl/hmac.h>
+
+#define MAX_PARAMS 8
+#define BENCH_COUNT 10
+#define GRID_START -3.0
+#define GRID_END   3.0
+#define GRID_STEP  0.2
+
+typedef struct {
+    const char* name;
+    double (*fn)(double);
+} Benchmark;
+
+typedef struct {
+    double xs[128];
+    double ys[128];
+    size_t n;
+} BenchData;
+
+typedef struct {
+    double eff;
+    double compl;
+    double params[MAX_PARAMS];
+    size_t param_count;
+    double bench_eff[BENCH_COUNT];
+} EvalResult;
+
+typedef struct {
+    double eff;
+    double compl;
+    int step;
+    char formula[256];
+} BestEntry;
+
+static double bench0(double x){ return sin(x)+0.5*x; }
+static double bench1(double x){ return cos(x); }
+static double bench2(double x){ return exp(-x*x); }
+static double bench3(double x){ return x*x*x - 0.5*x; }
+static double bench4(double x){ return fabs(x); }
+static double bench5(double x){ return x>0.0?x:-0.5*x; }
+static double bench6(double x){ return tanh(x); }
+static double bench7(double x){ return 1.0/(1.0+exp(-x)); }
+static double bench8(double x){ return sin(2.0*x); }
+static double bench9(double x){ return log(fabs(x)+1.0); }
+
+static const Benchmark g_benchmarks[BENCH_COUNT] = {
+    {"sin+x", bench0},
+    {"cos", bench1},
+    {"gauss", bench2},
+    {"cubic", bench3},
+    {"abs", bench4},
+    {"piecewise", bench5},
+    {"tanh", bench6},
+    {"sigmoid", bench7},
+    {"sin2x", bench8},
+    {"log1p", bench9}
+};
+
+static BenchData g_bench_data[BENCH_COUNT];
+static bool g_bench_ready=false;
+static BestEntry g_best[3];
+static size_t g_best_count=0;
+static char g_last_merkle[65]={0};
+
+static void hex_encode(const unsigned char* in, size_t n, char* out){
+    static const char* h="0123456789abcdef";
+    for(size_t i=0;i<n;i++){ out[2*i]=h[(in[i]>>4)&0xF]; out[2*i+1]=h[in[i]&0xF]; }
+    out[2*n]=0;
+}
+
+static void sha256_hex_local(const unsigned char* data, size_t n, char out[65]){
+    unsigned char buf[SHA256_DIGEST_LENGTH];
+    SHA256(data, n, buf);
+    hex_encode(buf, SHA256_DIGEST_LENGTH, out);
+}
+
+static void ensure_bench_data(void){
+    if(g_bench_ready) return;
+    for(size_t bi=0; bi<BENCH_COUNT; ++bi){
+        BenchData* bd=&g_bench_data[bi];
+        double x=GRID_START;
+        size_t idx=0;
+        while(x<=GRID_END+1e-9 && idx<sizeof(bd->xs)/sizeof(bd->xs[0])){
+            bd->xs[idx]=x;
+            bd->ys[idx]=g_benchmarks[bi].fn(x);
+            idx++;
+            x+=GRID_STEP;
+        }
+        bd->n=idx;
+    }
+    g_bench_ready=true;
+}
 
 static double prng01(uint64_t* s){
     uint64_t x=*s; x^=x>>12; x^=x<<25; x^=x>>27; *s=x;
     return (x*2685821657736338717ULL)/(double)UINT64_MAX;
 }
 
-static double target(double x){ return sin(x)+0.5*x; }
-
-static double eff_of(const Formula* f){
-    double mse=0.0; int n=0;
-    for(double x=-3.0;x<=3.0;x+=0.2){
-        double e=f_eval(f,x)-target(x); mse+=e*e; n++;
+static double mse_loss(const Formula* f, const double* params, size_t param_count, const BenchData* data){
+    double sum=0.0;
+    size_t i=0;
+#if defined(__SSE2__)
+    __m128d acc = _mm_setzero_pd();
+    for(; i+1<data->n; i+=2){
+        double fx0=f_eval(f, params, param_count, data->xs[i]);
+        double fx1=f_eval(f, params, param_count, data->xs[i+1]);
+        double err0=fx0-data->ys[i];
+        double err1=fx1-data->ys[i+1];
+        __m128d e=_mm_set_pd(err1, err0);
+        acc=_mm_add_pd(acc, _mm_mul_pd(e,e));
     }
-    mse/=n; return 1.0/(1.0+mse);
+    double buf[2];
+    _mm_storeu_pd(buf, acc);
+    sum += buf[0]+buf[1];
+#endif
+    for(; i<data->n; ++i){
+        double fx=f_eval(f, params, param_count, data->xs[i]);
+        double err=fx-data->ys[i];
+        sum+=err*err;
+    }
+    return sum/(double)data->n;
+}
+
+static double mse_and_grad(const Formula* f, const double* params, size_t param_count,
+                           const BenchData* data, double* grad_out){
+    double loss=0.0;
+    if(grad_out) memset(grad_out,0,param_count*sizeof(double));
+    double tmp[MAX_PARAMS];
+    for(size_t i=0;i<data->n;i++){
+        memset(tmp,0,param_count*sizeof(double));
+        double fx=f_eval_grad(f, params, param_count, data->xs[i], tmp);
+        double err=fx-data->ys[i];
+        loss+=err*err;
+        if(grad_out){
+            for(size_t j=0;j<param_count;j++) grad_out[j]+=2.0*err*tmp[j]/(double)data->n;
+        }
+    }
+    return loss/(double)data->n;
+}
+
+static void init_params(double* params, size_t count){
+    static const double grid[]={-2.0,-1.0,0.0,1.0,2.0};
+    for(size_t i=0;i<count;i++) params[i]=grid[i%5];
+}
+
+static void project_params(double* params, size_t count){
+    for(size_t i=0;i<count;i++){
+        if(params[i]>5.0) params[i]=5.0;
+        if(params[i]<-5.0) params[i]=-5.0;
+    }
+}
+
+static void optimize_params(const Formula* f, double* params, size_t count, const BenchData* data){
+    if(count==0) return;
+    double m[MAX_PARAMS]={0}, v[MAX_PARAMS]={0};
+    const double beta1=0.9, beta2=0.999, eps=1e-8, lr=0.05;
+    double b1=1.0, b2=1.0;
+    for(int iter=1; iter<=200; ++iter){
+        double grad[MAX_PARAMS]={0};
+        mse_and_grad(f, params, count, data, grad);
+        b1*=beta1; b2*=beta2;
+        for(size_t i=0;i<count;i++){
+            m[i]=beta1*m[i]+(1.0-beta1)*grad[i];
+            v[i]=beta2*v[i]+(1.0-beta2)*grad[i]*grad[i];
+            double m_hat=m[i]/(1.0-b1);
+            double v_hat=v[i]/(1.0-b2);
+            params[i]-=lr*m_hat/(sqrt(v_hat)+eps);
+        }
+        project_params(params, count);
+    }
+}
+
+static EvalResult evaluate_formula(const Formula* f){
+    EvalResult r; memset(&r,0,sizeof(r));
+    ensure_bench_data();
+    int max_idx=f_max_param_index(f);
+    if(max_idx>=0 && max_idx<MAX_PARAMS){
+        r.param_count=(size_t)(max_idx+1);
+        init_params(r.params, r.param_count);
+        optimize_params(f, r.params, r.param_count, &g_bench_data[0]);
+    }
+    double mse=mse_loss(f, r.params, r.param_count, &g_bench_data[0]);
+    r.eff=1.0/(1.0+mse);
+    r.compl=(double)f_complexity(f);
+    for(size_t i=0;i<BENCH_COUNT;i++){
+        double bench_mse=mse_loss(f, r.params, r.param_count, &g_bench_data[i]);
+        r.bench_eff[i]=1.0/(1.0+bench_mse);
+    }
+    return r;
+}
+
+static void update_memory(int step, const char* formula, double eff, double compl){
+    BestEntry candidate={.eff=eff,.compl=compl,.step=step};
+    snprintf(candidate.formula, sizeof(candidate.formula), "%s", formula);
+    size_t pos=g_best_count<3?g_best_count:3;
+    if(pos<3){ g_best[pos]=candidate; g_best_count++; }
+    else g_best[2]=candidate;
+    // sort descending by eff
+    for(size_t i=0;i<g_best_count;i++){
+        for(size_t j=i+1;j<g_best_count;j++){
+            if(g_best[j].eff>g_best[i].eff){ BestEntry tmp=g_best[i]; g_best[i]=g_best[j]; g_best[j]=tmp; }
+        }
+    }
+}
+
+static void summarize_memory(char* out, size_t n){
+    if(n==0) return;
+    size_t off=0;
+    int wrote = snprintf(out, n, "best[");
+    if(wrote<0) return;
+    off = (size_t)wrote;
+    if(off>=n){
+        out[n-1]=0;
+        return;
+    }
+    for(size_t i=0;i<g_best_count;i++){
+        if(off>=n) break;
+        size_t remain = n-off;
+        wrote=snprintf(out+off, remain,
+                       "#%zu:step=%d eff=%.3f compl=%.1f %s%s",
+                       i+1, g_best[i].step, g_best[i].eff, g_best[i].compl,
+                       g_best[i].formula, (i+1<g_best_count)?"; ":"");
+        if(wrote<0) break;
+        if((size_t)wrote >= remain){
+            off=n;
+            break;
+        }
+        off += (size_t)wrote;
+    }
+    if(off<n){
+        size_t remain = n-off;
+        wrote = snprintf(out+off, remain, "]");
+        if(wrote<0 && n>0) out[n-1]=0;
+    } else if(n>0){
+        out[n-1]=0;
+    }
+}
+
+static double vote_softmax_avg(const double votes[10], double temperature){
+    double temp = (temperature>1e-3)?temperature:1e-3;
+    double maxv=votes[0];
+    for(int i=1;i<10;i++) if(votes[i]>maxv) maxv=votes[i];
+    double num=0.0, den=0.0;
+    for(int i=0;i<10;i++){
+        double w=exp((votes[i]-maxv)/temp);
+        num+=votes[i]*w;
+        den+=w;
+    }
+    return (den>0.0)?(num/den):0.0;
+}
+
+static int cmp_pair(const void* a, const void* b){
+    const double* da=(const double*)a;
+    const double* db=(const double*)b;
+    if(da[0]<db[0]) return -1;
+    if(da[0]>db[0]) return 1;
+    return 0;
+}
+
+static double vote_weighted_median(const double votes[10]){
+    double pairs[10][2];
+    double total=0.0;
+    for(int i=0;i<10;i++){
+        double w=votes[i];
+        if(w<0.0) w=0.0;
+        pairs[i][0]=votes[i];
+        pairs[i][1]=w;
+        total+=w;
+    }
+    if(total<=1e-9) return 0.0;
+    qsort(pairs, 10, sizeof(pairs[0]), cmp_pair);
+    double acc=0.0;
+    for(int i=0;i<10;i++){
+        acc+=pairs[i][1];
+        if(acc>=total*0.5) return pairs[i][0];
+    }
+    return pairs[9][0];
+}
+
+static void compute_merkle(const char* prev_merkle, ReasonBlock* b){
+    static const char zeros[65]="0000000000000000000000000000000000000000000000000000000000000000";
+    const char* prev = (prev_merkle && prev_merkle[0])?prev_merkle:zeros;
+    b->merkle[0]=0;
+    char payload[4096];
+    int len = rb_payload_json(b, payload, sizeof(payload));
+    if(len<0) return;
+    size_t prev_len=strlen(prev);
+    size_t total=prev_len + (size_t)len;
+    unsigned char* buf=(unsigned char*)malloc(total);
+    memcpy(buf, prev, prev_len);
+    memcpy(buf+prev_len, payload, (size_t)len);
+    sha256_hex_local(buf, total, b->merkle);
+    free(buf);
 }
 
 static Formula* propose(const double vote[10], uint64_t seed){
     uint64_t s=seed;
-    int choice=(int)floor(prng01(&s)*5.0);
+    int choice=(int)floor(prng01(&s)*6.0);
     switch(choice){
         case 0: return f_add(f_x(), f_sin(f_x()));
-        case 1: return f_sin(f_mul(f_const(0.1 + 2.9*vote[2]), f_x()));
+        case 1: return f_sigmoid(f_add(f_param(0), f_mul(f_param(1), f_x())));
         case 2: return f_add(f_mul(f_const(-2+4*vote[0]), f_sin(f_x())),
                              f_mul(f_const(-1+2*vote[1]), f_x()));
-        case 3: return f_const(-1+2*vote[3]);
-        default: return f_const(-2+4*vote[4]);
+        case 3: return f_max(f_abs(f_x()), f_const(vote[2]));
+        case 4: return f_add(f_exp(f_mul(f_const(0.2), f_x())), f_param(2));
+        default: return f_tanh(f_add(f_param(0), f_mul(f_param(1), f_x())));
     }
 }
 
 bool kolibri_step(const kolibri_config_t* cfg, int step, const char* prev_hash,
                   ReasonBlock* out, char out_hash[65]){
+    ensure_bench_data();
     memset(out,0,sizeof(*out));
-    out->step=step; out->parent=step-1; out->seed=cfg->seed^((uint64_t)step);
+    out->step=step; out->parent=(step>0)?(step-1):0; out->seed=cfg->seed^((uint64_t)step);
+    strncpy(out->fmt, "dsl-v1", sizeof(out->fmt)-1);
 
-    // simple "votes": pseudo weights
     uint64_t s=out->seed;
     for(int i=0;i<10;i++){
         double r = prng01(&s);
         out->votes[i] = 0.5 + 0.5*cos(step*0.17 + r*6.28318);
         if(out->votes[i] < cfg->quorum) out->votes[i]=0.0;
     }
+    out->vote_softmax = vote_softmax_avg(out->votes, cfg->temperature);
+    out->vote_median = vote_weighted_median(out->votes);
 
     Formula* f = propose(out->votes, out->seed);
-    out->eff = eff_of(f);
-    out->compl = (double)f_complexity(f);
+    EvalResult er = evaluate_formula(f);
+    out->eff = er.eff;
+    out->compl = er.compl;
+    out->param_count = (int)er.param_count;
+    for(size_t i=0;i<er.param_count;i++) out->params[i]=er.params[i];
+    for(size_t i=0;i<BENCH_COUNT;i++) out->bench_eff[i]=er.bench_eff[i];
     f_render(f, out->formula, sizeof(out->formula));
+
+    update_memory(step, out->formula, out->eff, out->compl);
+    summarize_memory(out->memory, sizeof(out->memory));
+
+    if(prev_hash && *prev_hash) snprintf(out->prev, sizeof(out->prev), "%s", prev_hash);
+
+    compute_merkle(g_last_merkle, out);
+
+    char payload[4096];
+    int len = rb_payload_json(out, payload, sizeof(payload));
+    if(len<0){ f_free(f); return false; }
+
+    char hash_hex[65];
+    sha256_hex_local((unsigned char*)payload, (size_t)len, hash_hex);
+    const char* key = getenv("KOLIBRI_HMAC_KEY");
+    if(!key) key = "insecure-key";
+    unsigned char* mac = HMAC(EVP_sha256(), key, (int)strlen(key),
+                              (unsigned char*)payload, (size_t)len, NULL, NULL);
+    char hmac_hex[65];
+    hex_encode(mac, 32, hmac_hex);
+    snprintf(out->hash, sizeof(out->hash), "%s", hash_hex);
+    snprintf(out->hmac, sizeof(out->hmac), "%s", hmac_hex);
+    if(out_hash) snprintf(out_hash, 65, "%s", hash_hex);
+
+    if(!chain_append("logs/chain.jsonl", out)){ f_free(f); return false; }
+
+    snprintf(g_last_merkle, sizeof(g_last_merkle), "%s", out->merkle);
+
     f_free(f);
-
-    if(prev_hash && *prev_hash) strncpy(out->prev, prev_hash, 65);
-
-    // append to chain (hash/hmac computed over canonical JSON payload)
-    if(!chain_append("logs/chain.jsonl", out)) return false;
-
-    // compute the same payload to return its hash
-    char payload[4096]; int m = rb_payload_json(out, payload, sizeof(payload));
-    if(m>0){
-        // hash in out_hash is for convenience upstream
-        extern void __sha256_hex(const unsigned char*, size_t, char*);
-    }
-    // simple: reload last line for hash
-    ReasonBlock* arr=NULL; size_t n=0;
-    if(chain_load("logs/chain.jsonl",&arr,&n) && n>0){
-        strncpy(out_hash, arr[n-1].hash, 65);
-        free(arr);
-        return true;
-    }
-    return false;
+    return true;
 }

--- a/backend/src/dsl.c
+++ b/backend/src/dsl.c
@@ -3,45 +3,258 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include <stdbool.h>
 
-static Formula* fn(NodeType t){ Formula* f=(Formula*)calloc(1,sizeof(Formula)); f->t=t; return f; }
+static Formula* fn(NodeType t){
+    Formula* f=(Formula*)calloc(1,sizeof(Formula));
+    f->t=t;
+    f->param_index=-1;
+    return f;
+}
+
 Formula* f_const(double v){ Formula* f=fn(F_CONST); f->v=v; return f; }
+Formula* f_param(int idx){ Formula* f=fn(F_PARAM); f->param_index=idx; return f; }
 Formula* f_x(){ return fn(F_VAR_X); }
 Formula* f_add(Formula* a, Formula* b){ Formula* f=fn(F_ADD); f->a=a; f->b=b; return f; }
 Formula* f_sub(Formula* a, Formula* b){ Formula* f=fn(F_SUB); f->a=a; f->b=b; return f; }
 Formula* f_mul(Formula* a, Formula* b){ Formula* f=fn(F_MUL); f->a=a; f->b=b; return f; }
 Formula* f_div(Formula* a, Formula* b){ Formula* f=fn(F_DIV); f->a=a; f->b=b; return f; }
+Formula* f_min(Formula* a, Formula* b){ Formula* f=fn(F_MIN); f->a=a; f->b=b; return f; }
+Formula* f_max(Formula* a, Formula* b){ Formula* f=fn(F_MAX); f->a=a; f->b=b; return f; }
 Formula* f_sin(Formula* a){ Formula* f=fn(F_SIN); f->a=a; return f; }
+Formula* f_cos(Formula* a){ Formula* f=fn(F_COS); f->a=a; return f; }
+Formula* f_exp(Formula* a){ Formula* f=fn(F_EXP); f->a=a; return f; }
+Formula* f_log(Formula* a){ Formula* f=fn(F_LOG); f->a=a; return f; }
+Formula* f_pow(Formula* a, Formula* b){ Formula* f=fn(F_POW); f->a=a; f->b=b; return f; }
+Formula* f_tanh(Formula* a){ Formula* f=fn(F_TANH); f->a=a; return f; }
+Formula* f_sigmoid(Formula* a){ Formula* f=fn(F_SIGMOID); f->a=a; return f; }
+Formula* f_abs(Formula* a){ Formula* f=fn(F_ABS); f->a=a; return f; }
 
-double f_eval(const Formula* f, double x){
+static double safe_div(double num, double den){
+    if(!isfinite(den) || fabs(den)<1e-9) return 0.0;
+    return num/den;
+}
+
+static double safe_log(double v){
+    double guard = fabs(v) + 1e-9;
+    return log(guard);
+}
+
+static double safe_pow(double a, double b){
+    double guard = fabs(a) + 1e-9;
+    return pow(guard, b);
+}
+
+double f_eval(const Formula* f, const double* params, size_t param_count, double x){
     switch(f->t){
         case F_CONST: return f->v;
+        case F_PARAM: return (f->param_index>=0 && (size_t)f->param_index<param_count)? params[f->param_index] : 0.0;
         case F_VAR_X: return x;
-        case F_ADD: return f_eval(f->a,x)+f_eval(f->b,x);
-        case F_SUB: return f_eval(f->a,x)-f_eval(f->b,x);
-        case F_MUL: return f_eval(f->a,x)*f_eval(f->b,x);
-        case F_DIV: { double d=f_eval(f->b,x); return fabs(d)<1e-12?0.0:f_eval(f->a,x)/d; }
-        case F_SIN: return sin(f_eval(f->a,x));
+        case F_ADD: return f_eval(f->a,params,param_count,x)+f_eval(f->b,params,param_count,x);
+        case F_SUB: return f_eval(f->a,params,param_count,x)-f_eval(f->b,params,param_count,x);
+        case F_MUL: return f_eval(f->a,params,param_count,x)*f_eval(f->b,params,param_count,x);
+        case F_DIV: return safe_div(f_eval(f->a,params,param_count,x), f_eval(f->b,params,param_count,x));
+        case F_MIN: {
+            double av=f_eval(f->a,params,param_count,x);
+            double bv=f_eval(f->b,params,param_count,x);
+            return av<bv?av:bv;
+        }
+        case F_MAX: {
+            double av=f_eval(f->a,params,param_count,x);
+            double bv=f_eval(f->b,params,param_count,x);
+            return av>bv?av:bv;
+        }
+        case F_SIN: return sin(f_eval(f->a,params,param_count,x));
+        case F_COS: return cos(f_eval(f->a,params,param_count,x));
+        case F_EXP: return exp(f_eval(f->a,params,param_count,x));
+        case F_LOG: return safe_log(f_eval(f->a,params,param_count,x));
+        case F_POW: return safe_pow(f_eval(f->a,params,param_count,x), f_eval(f->b,params,param_count,x));
+        case F_TANH: return tanh(f_eval(f->a,params,param_count,x));
+        case F_SIGMOID: {
+            double v=f_eval(f->a,params,param_count,x);
+            double e=exp(-v);
+            return 1.0/(1.0+e);
+        }
+        case F_ABS: return fabs(f_eval(f->a,params,param_count,x));
     }
     return 0.0;
+}
+
+static void zero_grad(double* g, size_t n){ if(g) memset(g,0,n*sizeof(double)); }
+
+static double* new_grad_buffer(size_t n){
+    if(n==0) return NULL;
+    double* g=(double*)calloc(n,sizeof(double));
+    return g;
+}
+
+static void add_grad(double* dst, const double* src, size_t n, double scale){
+    if(!dst || !src) return;
+    for(size_t i=0;i<n;i++) dst[i]+=src[i]*scale;
+}
+
+static double f_eval_grad_internal(const Formula* f, const double* params, size_t param_count,
+                                   double x, double* grad_out){
+    switch(f->t){
+        case F_CONST:
+            return f->v;
+        case F_PARAM:
+            if(grad_out && f->param_index>=0 && (size_t)f->param_index<param_count){
+                grad_out[f->param_index]+=1.0;
+            }
+            return (f->param_index>=0 && (size_t)f->param_index<param_count)? params[f->param_index] : 0.0;
+        case F_VAR_X:
+            return x;
+        case F_ADD:
+        case F_SUB:
+        case F_MUL:
+        case F_DIV:
+        case F_MIN:
+        case F_MAX:
+        case F_POW: {
+            double* ga = grad_out?new_grad_buffer(param_count):NULL;
+            double* gb = grad_out?new_grad_buffer(param_count):NULL;
+            double av = f_eval_grad_internal(f->a, params, param_count, x, ga);
+            double bv = (f->b)?f_eval_grad_internal(f->b, params, param_count, x, gb):0.0;
+            double res=0.0;
+            switch(f->t){
+                case F_ADD:
+                    res = av + bv;
+                    if(grad_out){ add_grad(grad_out, ga, param_count, 1.0); add_grad(grad_out, gb, param_count, 1.0); }
+                    break;
+                case F_SUB:
+                    res = av - bv;
+                    if(grad_out){ add_grad(grad_out, ga, param_count, 1.0); add_grad(grad_out, gb, param_count, -1.0); }
+                    break;
+                case F_MUL:
+                    res = av * bv;
+                    if(grad_out){
+                        add_grad(grad_out, ga, param_count, bv);
+                        add_grad(grad_out, gb, param_count, av);
+                    }
+                    break;
+                case F_DIV: {
+                    double denom = fabs(bv)<1e-9?1e-9:bv;
+                    res = av/denom;
+                    if(grad_out){
+                        double inv = 1.0/(denom);
+                        double inv2 = inv*inv;
+                        add_grad(grad_out, ga, param_count, inv);
+                        add_grad(grad_out, gb, param_count, -av*inv2);
+                    }
+                    break;
+                }
+                case F_MIN:
+                case F_MAX: {
+                    bool take_a = (f->t==F_MIN)?(av<=bv):(av>=bv);
+                    res = take_a?av:bv;
+                    if(grad_out){ add_grad(grad_out, take_a?ga:gb, param_count, 1.0); }
+                    break;
+                }
+                case F_POW: {
+                    double guard = fabs(av)+1e-9;
+                    double powv = pow(guard, bv);
+                    double ln_guard = log(guard);
+                    res = powv;
+                    if(grad_out){
+                        double sign = (av>=0.0)?1.0:-1.0;
+                        add_grad(grad_out, ga, param_count, bv*pow(guard, bv-1.0)*sign);
+                        add_grad(grad_out, gb, param_count, powv*ln_guard);
+                    }
+                    break;
+                }
+                default: break;
+            }
+            if(ga) free(ga);
+            if(gb) free(gb);
+            return res;
+        }
+        case F_SIN:
+        case F_COS:
+        case F_EXP:
+        case F_LOG:
+        case F_TANH:
+        case F_SIGMOID:
+        case F_ABS: {
+            double* ga = grad_out?new_grad_buffer(param_count):NULL;
+            double av = f_eval_grad_internal(f->a, params, param_count, x, ga);
+            double res=0.0;
+            double factor=0.0;
+            switch(f->t){
+                case F_SIN: res=sin(av); factor=cos(av); break;
+                case F_COS: res=cos(av); factor=-sin(av); break;
+                case F_EXP: res=exp(av); factor=res; break;
+                case F_LOG: res=safe_log(av); factor=1.0/(fabs(av)+1e-9); break;
+                case F_TANH: res=tanh(av); factor=1.0-res*res; break;
+                case F_SIGMOID: {
+                    res=1.0/(1.0+exp(-av));
+                    factor=res*(1.0-res);
+                    break;
+                }
+                case F_ABS: res=fabs(av); factor=(av>=0.0)?1.0:-1.0; break;
+                default: break;
+            }
+            if(grad_out){ add_grad(grad_out, ga, param_count, factor); }
+            if(ga) free(ga);
+            return res;
+        }
+    }
+    return 0.0;
+}
+
+double f_eval_grad(const Formula* f, const double* params, size_t param_count,
+                   double x, double* grad_out){
+    if(grad_out) zero_grad(grad_out, param_count);
+    return f_eval_grad_internal(f, params, param_count, x, grad_out);
 }
 
 int f_complexity(const Formula* f){
     if(!f) return 0;
     switch(f->t){
-        case F_CONST: case F_VAR_X: return 1;
-        case F_SIN: return 1 + f_complexity(f->a);
-        default: return 1 + f_complexity(f->a) + f_complexity(f->b);
+        case F_CONST:
+        case F_PARAM:
+        case F_VAR_X:
+            return 1;
+        case F_SIN:
+        case F_COS:
+        case F_EXP:
+        case F_LOG:
+        case F_TANH:
+        case F_SIGMOID:
+        case F_ABS:
+            return 1 + f_complexity(f->a);
+        case F_MIN:
+        case F_MAX:
+        case F_ADD:
+        case F_SUB:
+        case F_MUL:
+        case F_DIV:
+        case F_POW:
+            return 1 + f_complexity(f->a) + f_complexity(f->b);
     }
+    return 0;
 }
 
 static int render_rec(const Formula* f, char* out, size_t n){
     if(n==0) return -1;
     switch(f->t){
         case F_CONST: return snprintf(out, n, "%.6g", f->v);
+        case F_PARAM: return snprintf(out, n, "c%d", f->param_index);
         case F_VAR_X: return snprintf(out, n, "x");
-        case F_SIN: {
-            int m = snprintf(out, n, "sin(");
+        case F_SIN:
+        case F_COS:
+        case F_EXP:
+        case F_LOG:
+        case F_TANH:
+        case F_SIGMOID:
+        case F_ABS: {
+            const char* name = (f->t==F_SIN)?"sin":
+                               (f->t==F_COS)?"cos":
+                               (f->t==F_EXP)?"exp":
+                               (f->t==F_LOG)?"log":
+                               (f->t==F_TANH)?"tanh":
+                               (f->t==F_SIGMOID)?"sigmoid":"abs";
+            int m = snprintf(out, n, "%s(", name);
             if(m<0 || (size_t)m>=n) return -1;
             int k = render_rec(f->a, out+m, n-m); if(k<0) return -1;
             int t = m+k;
@@ -49,11 +262,25 @@ static int render_rec(const Formula* f, char* out, size_t n){
             if(c<0 || (size_t)(t+c)>=n) return -1;
             return t+c;
         }
+        case F_MIN:
+        case F_MAX: {
+            const char* name = (f->t==F_MIN)?"min":"max";
+            int m = snprintf(out, n, "%s(", name);
+            if(m<0 || (size_t)m>=n) return -1;
+            int k = render_rec(f->a, out+m, n-m); if(k<0) return -1; int t=m+k;
+            int c = snprintf(out+t, n-t, ","); if(c<0 || (size_t)(t+c)>=n) return -1; t+=c;
+            int q = render_rec(f->b, out+t, n-t); if(q<0) return -1; t+=q;
+            int e = snprintf(out+t, n-t, ")"); if(e<0 || (size_t)(t+e)>=n) return -1;
+            return t+e;
+        }
         default: {
-            char op = (f->t==F_ADD)?'+':(f->t==F_SUB)?'-':(f->t==F_MUL?'*':'/');
+            const char* op = (f->t==F_ADD)?"+":
+                             (f->t==F_SUB)?"-":
+                             (f->t==F_MUL)?"*":
+                             (f->t==F_DIV)?"/":"^";
             int m = snprintf(out, n, "("); if(m<0||(size_t)m>=n) return -1;
             int k = render_rec(f->a, out+m, n-m); if(k<0) return -1; int t=m+k;
-            int c = snprintf(out+t, n-t, " %c ", op); if(c<0||(size_t)(t+c)>=n) return -1; t+=c;
+            int c = snprintf(out+t, n-t, " %s ", op); if(c<0||(size_t)(t+c)>=n) return -1; t+=c;
             int q = render_rec(f->b, out+t, n-t); if(q<0) return -1; t+=q;
             int e = snprintf(out+t, n-t, ")"); if(e<0||(size_t)(t+e)>=n) return -1;
             return t+e;
@@ -68,3 +295,14 @@ int f_render(const Formula* f, char* out, size_t n){
 }
 
 void f_free(Formula* f){ if(!f) return; f_free(f->a); f_free(f->b); free(f); }
+
+int f_max_param_index(const Formula* f){
+    if(!f) return -1;
+    int m=-1;
+    if(f->t==F_PARAM && f->param_index>m) m=f->param_index;
+    int la=f_max_param_index(f->a);
+    int lb=f_max_param_index(f->b);
+    if(la>m) m=la;
+    if(lb>m) m=lb;
+    return m;
+}

--- a/backend/src/main_run.c
+++ b/backend/src/main_run.c
@@ -29,5 +29,9 @@ int main(int argc, char** argv){
                step, b.eff, b.compl, b.formula, hash);
         strncpy(prev, hash, 65);
     }
+    if(!chain_verify("logs/chain.jsonl", stdout)){
+        fprintf(stderr, "self-check verification failed\n");
+        return 1;
+    }
     return 0;
 }

--- a/backend/src/main_verify.c
+++ b/backend/src/main_verify.c
@@ -3,54 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <openssl/sha.h>
-#include <openssl/hmac.h>
-
-static void hex(const unsigned char* in, size_t n, char* out){
-    static const char* h="0123456789abcdef";
-    for(size_t i=0;i<n;i++){ out[2*i]=h[(in[i]>>4)&0xF]; out[2*i+1]=h[in[i]&0xF]; }
-    out[2*n]=0;
-}
-static void sha256_hex(const unsigned char* d, size_t n, char out[65]){
-    unsigned char buf[SHA256_DIGEST_LENGTH];
-    SHA256(d,n,buf); hex(buf, SHA256_DIGEST_LENGTH, out);
-}
-
 int main(int argc, char** argv){
     const char* path = (argc>1)? argv[1] : "logs/chain.jsonl";
-    ReasonBlock* arr=NULL; size_t n=0;
-    if(!chain_load(path,&arr,&n) || n==0){
-        fprintf(stderr,"No chain at %s\n", path);
-        return 1;
-    }
-    const char* k = getenv("KOLIBRI_HMAC_KEY");
-    if(!k) k = "insecure-key";
-
-    char prev[65]={0};
-    for(size_t i=0;i<n;i++){
-        ReasonBlock* b = &arr[i];
-        if(strcmp(b->prev, prev)!=0){
-            fprintf(stderr, "prev mismatch at step %llu\n", (unsigned long long)b->step);
-            free(arr); return 2;
-        }
-        char payload[4096]; int m = rb_payload_json(b, payload, sizeof(payload));
-        if(m<0){ free(arr); return 3; }
-        char h[65], mac_hex[65];
-        sha256_hex((unsigned char*)payload, (size_t)m, h);
-        if(strncmp(h, b->hash, 64)!=0){
-            fprintf(stderr, "hash mismatch at step %llu\n", (unsigned long long)b->step);
-            free(arr); return 4;
-        }
-        unsigned char* mac = HMAC(EVP_sha256(), k, (int)strlen(k),
-                                  (unsigned char*)payload, (size_t)m, NULL, NULL);
-        hex(mac, 32, mac_hex);
-        if(strncmp(mac_hex, b->hmac, 64)!=0){
-            fprintf(stderr, "hmac mismatch at step %llu\n", (unsigned long long)b->step);
-            free(arr); return 5;
-        }
-        strncpy(prev, h, 65);
-    }
-    printf("OK: chain verified (%zu blocks)\n", n);
-    free(arr);
-    return 0;
+    if(chain_verify(path, stdout)) return 0;
+    return 1;
 }

--- a/backend/src/reason.c
+++ b/backend/src/reason.c
@@ -14,17 +14,34 @@ static void esc(const char* s, char* out, size_t n){
 int rb_payload_json(const ReasonBlock* b, char* buf, size_t n){
     // deterministic JSON: no spaces; floats as %.17g; exactly 10 votes
     char fesc[512]; esc(b->formula, fesc, sizeof(fesc));
+    char memesc[512]; esc(b->memory, memesc, sizeof(memesc));
+    char fmtesc[64]; esc(b->fmt, fmtesc, sizeof(fmtesc));
+    char prev_esc[128]; esc(b->prev, prev_esc, sizeof(prev_esc));
+    char merkle_esc[128]; esc(b->merkle, merkle_esc, sizeof(merkle_esc));
     int off=0;
     off += snprintf(buf+off, n-off, "{\"step\":%llu,\"parent\":%llu,\"seed\":%llu,",
                     (unsigned long long)b->step,
                     (unsigned long long)b->parent,
                     (unsigned long long)b->seed);
-    off += snprintf(buf+off, n-off, "\"formula\":\"%s\",\"eff\":%.17g,\"compl\":%.17g,",
-                    fesc, b->eff, b->compl);
-    off += snprintf(buf+off, n-off, "\"prev\":\"%s\",\"votes\":[", b->prev);
+    off += snprintf(buf+off, n-off, "\"fmt\":\"%s\",\"formula\":\"%s\",", fmtesc, fesc);
+    off += snprintf(buf+off, n-off, "\"param_count\":%d,\"params\":[", b->param_count);
+    for(int i=0;i<b->param_count;i++){
+        off += snprintf(buf+off, n-off, "%.17g%s", b->params[i], (i<b->param_count-1)?",":"");
+    }
+    off += snprintf(buf+off, n-off, "]");
+    off += snprintf(buf+off, n-off, ",\"eff\":%.17g,\"compl\":%.17g,",
+                    b->eff, b->compl);
+    off += snprintf(buf+off, n-off, "\"prev\":\"%s\",\"votes\":[", prev_esc);
     for(int i=0;i<10;i++){
         off += snprintf(buf+off, n-off, "%.17g%s", b->votes[i], (i<9)?",":"]}");
     }
+    off += snprintf(buf+off, n-off, ",\"vote_softmax\":%.17g,\"vote_median\":%.17g,",
+                    b->vote_softmax, b->vote_median);
+    off += snprintf(buf+off, n-off, "\"bench\":[");
+    for(int i=0;i<10;i++){
+        off += snprintf(buf+off, n-off, "%.17g%s", b->bench_eff[i], (i<9)?",":"]");
+    }
+    off += snprintf(buf+off, n-off, ",\"memory\":\"%s\",\"merkle\":\"%s\"}", memesc, merkle_esc);
     if(off<0 || (size_t)off>=n) return -1;
     return off;
 }


### PR DESCRIPTION
## Summary
- extend the DSL with guarded math primitives, parameter nodes, and gradient evaluation helpers
- optimize symbolic search with Adam-tuned parameters, benchmark reporting, vote aggregation, and best-formula memory
- enrich reason blocks with params/bench metrics, Merkle fmt metadata, reusable chain verification, and runner self-check

## Testing
- `make -j2`
- `./bin/kolibri_run configs/kolibri.json`
- `./bin/kolibri_verify logs/chain.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_68cf54b4505883238dfc8923a23c799d