### PR TITLE
Fix ReasonBlock JSON closing and add payload test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ LDFLAGS := $(OPENSSL_LIBS) -lm
 SRC := backend/src
 BIN_DIR := bin
 BINS := $(BIN_DIR)/kolibri_run $(BIN_DIR)/kolibri_verify $(BIN_DIR)/kolibri_replay
+TEST_BIN := $(BIN_DIR)/reason_payload_test
 
 all: $(BIN_DIR) $(BINS)
 
@@ -35,6 +36,13 @@ $(BIN_DIR)/kolibri_verify: $(SRC)/main_verify.c $(SRC)/dsl.c $(SRC)/chainio.c $(
 
 $(BIN_DIR)/kolibri_replay: $(SRC)/main_replay.c $(SRC)/core.c $(SRC)/dsl.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c
 	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
+
+$(TEST_BIN): backend/tests/reason_payload_test.c $(SRC)/reason.c
+	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
+
+.PHONY: tests
+tests: $(BIN_DIR) $(TEST_BIN)
+	python3 tests/test_reason_payload.py
 
 clean:
 	rm -rf $(BIN_DIR) logs/*.jsonl logs/*.json

--- a/backend/src/reason.c
+++ b/backend/src/reason.c
@@ -23,8 +23,9 @@ int rb_payload_json(const ReasonBlock* b, char* buf, size_t n){
                     fesc, b->eff, b->compl);
     off += snprintf(buf+off, n-off, "\"prev\":\"%s\",\"votes\":[", b->prev);
     for(int i=0;i<10;i++){
-        off += snprintf(buf+off, n-off, "%.17g%s", b->votes[i], (i<9)?",":"]}");
+        off += snprintf(buf+off, n-off, "%.17g%s", b->votes[i], (i<9)?",":"]");
     }
+    off += snprintf(buf+off, n-off, "}");
     if(off<0 || (size_t)off>=n) return -1;
     return off;
 }

--- a/backend/tests/reason_payload_test.c
+++ b/backend/tests/reason_payload_test.c
@@ -1,0 +1,27 @@
+#include "reason.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void){
+    ReasonBlock b = {0};
+    b.step = 42;
+    b.parent = 21;
+    b.seed = 7;
+    b.eff = 0.25;
+    b.compl = 0.75;
+    strncpy(b.formula, "a+b", sizeof(b.formula)-1);
+    strncpy(b.prev, "prev-hash", sizeof(b.prev)-1);
+    for(int i = 0; i < 10; i++){
+        b.votes[i] = 0.1 * (double)(i + 1);
+    }
+
+    char buf[1024];
+    int len = rb_payload_json(&b, buf, sizeof(buf));
+    if(len < 0 || (size_t)len >= sizeof(buf)){
+        fprintf(stderr, "rb_payload_json failed\n");
+        return 1;
+    }
+
+    fwrite(buf, 1, (size_t)len, stdout);
+    return 0;
+}

--- a/tests/test_reason_payload.py
+++ b/tests/test_reason_payload.py
@@ -1,0 +1,50 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    binary = repo_root / "bin" / "reason_payload_test"
+    result = subprocess.run(
+        [str(binary)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = result.stdout.strip()
+
+    data = json.loads(payload)
+    expected_order = [
+        "step",
+        "parent",
+        "seed",
+        "formula",
+        "eff",
+        "compl",
+        "prev",
+        "votes",
+    ]
+    search_start = 0
+    for key in expected_order:
+        token = f'"{key}":'
+        position = payload.find(token, search_start)
+        if position == -1:
+            raise AssertionError(f"missing field order for {key}")
+        search_start = position + len(token)
+
+    if not payload.endswith("}"):
+        raise AssertionError("payload must end with closing brace")
+
+    if payload.count("}") != 1:
+        raise AssertionError("payload must contain exactly one closing brace")
+
+    if payload.count("]") != 1:
+        raise AssertionError("votes array must close exactly once")
+
+    if len(data.get("votes", [])) != 10:
+        raise AssertionError("votes array must have exactly 10 entries")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adjust rb_payload_json so the votes loop only emits a closing bracket and append the final brace once at the end
- add a small C harness plus a Python check to serialize a ReasonBlock and validate its JSON structure
- wire the new regression check into `make tests`

## Testing
- make -j"$(nproc)"
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68cf59d7c1c88323bb0c70ef3baa495d