### PR TITLE
Refine phase 2 execution plan for capabilities 41-120

### DIFF
--- a/docs/phase2_capabilities_roadmap.md
+++ b/docs/phase2_capabilities_roadmap.md
@@ -1,0 +1,320 @@
+# Kolibri Phase 2 Execution Blueprint (Capabilities 41–120)
+
+This document replaces the prior high-level roadmap with an execution-ready blueprint that decomposes capabilities 41–120
+into concrete workstreams, service changes, deliverables, and validation gates. It assumes Phase 1 foundations (core runtime,
+policy service, baseline planner, evaluation harness) are in production. Workstreams are sequenced into four overlapping waves
+with explicit dependencies, but each table can feed directly into a backlog tool.
+
+## Delivery Governance
+
+- **Wave Cadence:**
+  - **Wave A (Weeks 1–6):** Launch SkillStore v1.0, predictive planner core, initial active-learning loop.
+  - **Wave B (Weeks 5–11):** Security, explainability, and simulation layers hardened in parallel.
+  - **Wave C (Weeks 9–16):** Multiplatform UX, offline/edge readiness, advanced observability.
+  - **Wave D (Weeks 14–22):** Device ecosystem, developer portal, monetization scale, CI/CD.
+- **Program RACI:** Marketplace PMO owns items 41–48; Planner Guild owns 49–56; Data Learning Guild owns 57–64; Simulation SRE
+  owns 65–72; Experience Tribe owns 73–80; Trust & Governance owns 81–88; Platform Ops owns 89–96; Edge Pod owns 97–104;
+  Device Partnerships owns 105–112; Developer Relations owns 113–120.
+- **Release Gates:** Each capability bundle requires (a) security sign-off, (b) observability instrumentation linked to the
+  Kolibri action journal, and (c) stakeholder walkthrough recorded in Confluence.
+
+## 1. SkillStore & Marketplace (41–48)
+
+### Architecture & Components
+- Extend **skill_catalog** service with ranking API (`GET /v1/skills?sort=`) sourcing vectors from quality scoring jobs,
+  review aggregates, and policy compliance signals. Ranking weights stored in `marketplace.rank_profile` table.
+- Create **skill_static_analyzer** (Rust + Wasm sandbox) invoked by CI pipeline; supports manifest linting, dependency
+  allowlists, and CVE signature scanning.
+- Introduce **permission_broker** microservice issuing scoped OAuth tokens based on trust tiers, context (user, org, mission),
+  and runtime policy evaluation; persists grants in `permissions.dynamic_grants`.
+- Harden **skill_sandbox_runner** with Firecracker microVM profiles and resource quota controller; attach virtualized IO bus
+  (`vsock`) for deterministic replay.
+- Publish **kolibri-skill-sdk** (Node + Python templates) featuring CLI generator (`kolibri-skill init`) and Jest/PyTest harnesses.
+- Stand up **partner_program_portal** (Next.js) for grant workflow, KPI dashboards, and compliance checklists.
+- Embed **skill_chain_composer** into planner UI and backend aggregator to orchestrate composite missions via DAG manifests.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 41 | SkillStore ranking | Build ranking pipeline jobs; expose weighted API; QA A/B experiments | Marketplace PM | Data warehouse, action journal |
+| 42 | Static analysis | Implement analyzer runners, rule packs; wire into CI gating | Security Eng | Skill manifest schema |
+| 43 | Dynamic permissions | Design trust tiers; implement broker service + UI prompts | Security PM | Policy controller, identity |
+| 44 | Hybrid monetization | Add Stripe/Braintree adapters, subscription ledger, enterprise invoicing | BizOps PM | Billing core |
+| 45 | Sandbox | Define VM templates, quota enforcement, logging + replay | Platform Ops | Firecracker cluster |
+| 46 | SDK | Scaffold CLI, boilerplates, local mocks, documentation | DevRel | Marketplace API stability |
+| 47 | Partner acceleration | Launch portal, grant workflow, concierge SLAs | Partnerships | SDK availability |
+| 48 | Skill chains | DAG schema, compatibility validator, planner integration | Planner Guild | Permission broker |
+
+### Validation
+- Automated analyzer coverage ≥95% for known insecure patterns; sandbox CPU throttling verified under load test.
+- Monetization smoke tests covering subscription renewals, microtransaction refunds, and enterprise seat expansion.
+- Partner beta cohort (≥10 partners) delivering skills via SDK + portal; composite mission success rate ≥90%.
+
+### Rollout
+- Wave A: Items 41–43 GA. Wave B: Items 44–45 GA, items 46–48 beta. Wave C: 46–48 GA with combined showcase mission.
+
+## 2. Task Planners (49–56)
+
+### Architecture & Components
+- Enhance **planner_service** with timeline projection module leveraging workload forecasts stored in `planner.timeline_model`.
+- Introduce **calendar_sync_gateway** (microservice) with connectors for Google, Apple, Exchange; supports OAuth token vault.
+- Expand **progress_analytics** pipeline to aggregate telemetry into progress snapshots and exportable reports.
+- Implement **workflow_engine** for conditional branching (state machine with guard conditions, trigger actions).
+- Integrate **voice_command_router** using streaming ASR (from multimodal stack) with confirmation dialogues and audit logs.
+- Deliver **process_designer UI** (React canvas) backed by template library in `planner.templates`.
+- Add **SLA_forecaster** using Monte Carlo simulation to compute completion risk and acceleration suggestions.
+- Build **enterprise_task_adapter** connectors for Jira, Asana, Monday with bi-directional updates.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 49 | Timeline forecast | Train forecasting model, integrate auto-redistribution heuristics | Planner Guild | Action journal |
+| 50 | Calendar sync | OAuth flows, conflict mediation, ICS normalizer | Planner Guild | Identity, secrets manager |
+| 51 | Progress reports | Telemetry schema updates, PDF/HTML exporters, notifications | Planner Guild | Analytics infra |
+| 52 | Conditional scenarios | State machine engine, UI builder, automated corrections | Planner Guild | Workflow engine |
+| 53 | Voice control | Streaming ASR integration, confirmation UX, logs | Experience Tribe | ASR stack |
+| 54 | Visual designer | Drag-drop editor, template versioning, compliance hints | Experience Tribe | Conditional engine |
+| 55 | Deadline predictions | Monte Carlo estimator, mitigation recommendations | Planner Guild | Timeline forecast |
+| 56 | Enterprise integration | Jira/Asana/Monday connectors, sync tests, SSO | Planner Guild | Calendar gateway |
+
+### Validation & Rollout
+- Shadow-mode forecast accuracy within ±10% over 4-week sample before GA.
+- Voice command pilot with 100 internal users; ≥95% confirmation accuracy.
+- Wave A: Items 49–50 GA. Wave B: 51–53 beta. Wave C: 54–56 GA after enterprise security review.
+
+## 3. Active Learning Engine (57–64)
+
+### Architecture & Components
+- Deploy **informative_sampler** microservice consuming inference telemetry and label history to prioritize examples.
+- Integrate **expert_simulator** (LLM distilled tutor) accessible via `POST /v1/expert/hints` for complex cases.
+- Launch **reward_ledger** smart contract (off-chain DB + token issuance service) tracking contributor rewards.
+- Build **data_quality_dashboard** (Superset) with metrics on noise, contradictions, staleness.
+- Instrument **distribution_monitor** jobs comparing live vs. training distributions using population stability index.
+- Add **counterexample_generator** harness producing adversarial prompts for hallucination resilience.
+- Publish **retrain_trigger_catalog** stored as YAML descriptors driving orchestrated retraining pipelines.
+- Secure data exchange via **obfuscation_gateway** performing tokenization, masking, and encryption before transfer.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 57 | Informative sampler | Feature extraction, acquisition functions, API integration | Data Learning | Telemetry bus |
+| 58 | Expert simulator | Model selection, evaluation, integration with planner | Data Learning | Active learning loop |
+| 59 | Rewards | Ledger schema, payout automation, fraud checks | BizOps | Billing, identity |
+| 60 | Quality dashboard | Metrics compute jobs, anomaly detection, Superset views | Data Learning | Warehouse |
+| 61 | Drift monitoring | PSI/KS metrics, alerting thresholds, notification hooks | Data Learning | Monitoring stack |
+| 62 | Counterexamples | Prompt generation harness, evaluation pipeline | Data Learning | Simulator |
+| 63 | Retraining triggers | Descriptor schema, orchestration integration, audit logs | Data Learning | CI/CD |
+| 64 | Secure transport | Obfuscation gateway, key rotation, compliance review | Security Eng | Data platform |
+
+### Validation & Rollout
+- Live AB test verifying annotation yield +40%; drift alerts triggered in staging scenario.
+- Wave A: 57–58 GA. Wave B: 59–61 beta. Wave C: 62–64 GA with compliance approval.
+
+## 4. Simulation & Testing (65–72)
+
+### Architecture & Components
+- Provision **simulation_hub** (Kubernetes cluster) hosting scenario pods for STEM, legal, creative missions with scoring API.
+- Extend **stress_test_orchestrator** injecting load, latency, and hardware fault simulations.
+- Generate **dialog_regression_builder** pipeline turning transcripts into pytest suites with golden outputs.
+- Build **digital_twin_factory** storing anonymized customer configurations, datasets, and evaluation runs.
+- Implement **model_tournament_manager** ranking model builds via KSI metrics and guardrails.
+- Integrate **reasoning_debugger** UI overlay linking planner steps to simulator traces.
+- Launch **bug_bounty_portal** with vulnerability intake, severity matrix, payout automation.
+- Schedule **external_benchmark_runner** executing HELM/MMLU/etc. with dashboards.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 65 | Virtual ranges | Scenario authoring tools, scoring rubrics, sandbox deployment | Simulation SRE | Skill sandbox |
+| 66 | Stress tests | Fault injection scripts, monitoring hooks, chaos drills | Simulation SRE | Autoscaling infra |
+| 67 | Regression generation | Transcript parser, test synthesizer, CI integration | QA Guild | Telemetry access |
+| 68 | Digital twins | Config ingestion, anonymization, sandbox orchestration | Simulation SRE | Data privacy |
+| 69 | Model competitions | Tournament scheduler, metrics calculation, leaderboard UI | Data Learning | Benchmark runner |
+| 70 | Visual debugger | Trace capture, UI overlay, devtools integration | Experience Tribe | Planner logs |
+| 71 | Bug bounty | Policy docs, submission portal, triage workflows | Security PM | Legal, finance |
+| 72 | External validation | Benchmark harness, reporting cadence, alerting | QA Guild | Simulation hub |
+
+### Validation & Rollout
+- Regression suite coverage ≥85% of top mission flows; bug bounty response SLA <7 days.
+- Wave B: 65–68 GA. Wave C: 69–72 GA with ongoing competitions.
+
+## 5. UX & Interfaces (73–80)
+
+### Architecture & Components
+- Develop **experience_shell** design system with responsive layouts and channel adapters (web, mobile, desktop, kiosk).
+- Integrate **voice_assistant_frontend** with animated avatars, real-time subtitles, and tactile cues.
+- Implement **collaborative_editor** using CRDT-based synchronization with attribution metadata.
+- Deliver **ar_control_surface** leveraging ARKit/ARCore anchors and IoT command streaming.
+- Ship **accessibility_center** for contrast, typography, motor support, captions, and screen-reader support.
+- Provide **contextual_learning_missions** triggered via in-app coach with telemetry-driven personalization.
+- Create **offline_task_console** (PWA) with background sync worker and conflict resolver.
+- Build **messaging_connector_suite** integrating Slack, Teams, WhatsApp, SAP via webhook adapters.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 73 | Multiplatform UI | Design system tokens, adaptive layouts, channel testing | Experience Tribe | Branding |
+| 74 | Voice assistant | Avatar engine, speech/visual sync, accessibility hooks | Experience Tribe | ASR/TTS |
+| 75 | Co-editing | CRDT engine, presence indicators, edit attribution | Experience Tribe | Identity |
+| 76 | AR interface | Spatial mapping, gesture controls, IoT bridge | Experience Tribe | Edge runtime |
+| 77 | Accessibility module | Preferences storage, WCAG audits, QA scripts | Experience Tribe | Design system |
+| 78 | Contextual learning | Mission authoring, telemetry triggers, analytics | Experience Tribe | Active learning |
+| 79 | Offline panel | PWA caching, sync conflict resolver, offline auth | Experience Tribe | Sync engine |
+| 80 | Messaging integration | Connector adapters, compliance logging, admin UI | Experience Tribe | Permission broker |
+
+### Validation & Rollout
+- Accessibility score ≥95 (Lighthouse); offline sync resolves ≥90% conflicts automatically.
+- Wave C: 73–79 GA sequentially; 80 staged rollouts aligned with enterprise partners.
+
+## 6. Explainability & Observability (81–88)
+
+### Architecture & Components
+- Create **reasoning_map_service** rendering DAG of reasoning steps with drill-down to evidence (action journal references).
+- Implement **attention_heatmap_engine** capturing modality/step attention weights for visualization.
+- Extend **confidence_estimator** to output confidence intervals and risk scenarios per response.
+- Build **user_annotation_service** storing annotations linked to reasoning steps and providing feedback loops.
+- Launch **degradation_alert_center** monitoring performance regressions with remediation playbooks.
+- Compute **trust_metrics_pipeline** attributing evidence contributions to final answer confidence.
+- Publish **audit_api_gateway** offering scoped access to signed logs for third parties with zero-knowledge proofs.
+- Add **decision_replay_player** enabling guided playback of missions for training.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 81 | Reasoning map | DAG schema, graph rendering, evidence links | Trust & Governance | Planner logs |
+| 82 | Attention heatmap | Capture hooks, visualization components, UI integration | Trust & Governance | Model telemetry |
+| 83 | Confidence intervals | Statistical models, risk scenario templating | Trust & Governance | Evaluation harness |
+| 84 | User annotations | Annotation UI, moderation, feedback ingestion | Trust & Governance | Reasoning map |
+| 85 | Degradation center | Alert rules, remediation workflows, notification routing | Trust & Governance | Monitoring stack |
+| 86 | Trust metrics | Contribution scoring, explanation UI, analytics | Trust & Governance | Confidence estimator |
+| 87 | Audit API | Scoped access controls, signed logs, API portal | Trust & Governance | Policy controller |
+| 88 | Replay mode | Session capture, playback UI, training scripts | Trust & Governance | Reasoning map |
+
+### Validation & Rollout
+- Explainability NPS >80; audit API penetration test passed; replay adoption across ≥5 enterprise customers.
+- Wave B: 81–84 GA. Wave C: 85–88 GA.
+
+## 7. Performance & Infrastructure (89–96)
+
+### Architecture & Components
+- Deploy **predictive_autoscaler** leveraging time-series models (Prophet) and reinforcement adjustments.
+- Integrate **inference_optimizer** with TensorRT/ONNX Runtime for mixed precision and graph compilation.
+- Introduce **rag_cache_service** with context+user deduplication, LRU eviction, and invalidation hooks.
+- Stand up **priority_task_queue** (Kafka + priority scheduler) ensuring SLA enforcement for mission-critical flows.
+- Add **cost_governance_layer** with budget policies, alerting, and recommendations.
+- Implement **continuous_profiler** (eBPF + NVML) streaming GPU/CPU metrics to Prometheus + Grafana.
+- Create **config_registry** storing environment manifests with versioning, diff, and rollback CLI.
+- Enable **canary_release_pipeline** orchestrating zero-downtime model/skill deployments with automated rollback.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 89 | Autoscaling | Demand forecasting, scaling policies, chaos drills | Platform Ops | Monitoring stack |
+| 90 | Inference optimization | Mixed precision pipeline, benchmarking, fallback modes | Platform Ops | Model artifacts |
+| 91 | RAG cache | Cache key design, eviction policies, invalidation hooks | Platform Ops | Retrieval service |
+| 92 | Priority queue | Scheduler implementation, SLA enforcement, instrumentation | Platform Ops | Mission orchestration |
+| 93 | Cost control | Budget model, alerting, exec dashboards | BizOps | Billing data |
+| 94 | Profiling | eBPF agents, NVML collectors, dashboards | Platform Ops | Observability stack |
+| 95 | Config registry | Manifest schema, CLI tools, rollback workflows | Platform Ops | GitOps |
+| 96 | Zero-downtime releases | Canary orchestration, traffic shadowing, rollback automation | Platform Ops | Config registry |
+
+### Validation & Rollout
+- Latency reduction ≥20%; cost overrun alerts triggered in staging tests; canary release success rate ≥99%.
+- Wave B: 89–92 GA. Wave C: 93–96 GA.
+
+## 8. Edge & Offline (97–104)
+
+### Architecture & Components
+- Produce **lightweight_model_suite** (quantized transformers, distillation) targeting mobile/IoT hardware.
+- Build **smart_sync_engine** resolving version conflicts with CRDT merges and policy-based arbitration.
+- Implement **hybrid_execution_router** routing heavy workloads to cloud on demand with user consent prompts.
+- Curate **offline_skill_pack** including local inference models, knowledge cache, and update scheduler.
+- Enable **personal_offline_training** harness leveraging on-device data with privacy-preserving aggregation.
+- Integrate **offline_fraud_detector** monitoring tampering attempts using integrity checks and anomaly detection.
+- Create **cache_management_console** for local storage quotas, purge policies, encryption status.
+- Automate **secure_backup_service** performing encrypted backups of preferences/settings with end-to-end keys.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 97 | Lightweight models | Distillation, quantization, device benchmarks | Edge Pod | Model artifacts |
+| 98 | Smart sync | CRDT engine, conflict UI, background sync | Edge Pod | Offline console |
+| 99 | Hybrid mode | Router service, consent UI, cost estimation | Edge Pod | Hybrid cloud |
+| 100 | Offline skills | Packaging, update scheduler, verification | Edge Pod | Lightweight models |
+| 101 | Offline training | Federated loop, privacy guards, evaluation | Edge Pod | Obfuscation gateway |
+| 102 | Fraud detection | Integrity checks, anomaly detection, response plan | Security Eng | Offline runtime |
+| 103 | Cache management | UI/CLI, policy enforcement, telemetry | Edge Pod | Offline console |
+| 104 | Secure backups | Key management, encrypted sync, recovery workflows | Security Eng | Backup service |
+
+### Validation & Rollout
+- Device benchmarks meet latency targets (<200ms offline inference); backup recovery drills completed quarterly.
+- Wave C: 97–101 GA; Wave D: 102–104 GA alongside hybrid deployments.
+
+## 9. Device Integrations (105–112)
+
+### Architecture & Components
+- Release **device_manufacturer_sdk** with reference firmware libraries and sample skills.
+- Define **robotics_control_protocol** (gRPC + mutual TLS) for industrial/robot integrations.
+- Deploy **video_analytics_pipeline** ingesting RTSP streams with on-device anonymization filters.
+- Build **automotive_interface_adapter** supporting Android Auto/CarPlay voice tasks.
+- Launch **smart_office_module** controlling lighting, HVAC, scheduling via IoT standards (Matter/KNX).
+- Integrate **medical_device_gateway** complying with HIPAA/GDPR, capturing vitals securely.
+- Create **smart_home_automation** scenarios with learnable routines and user feedback loops.
+- Publish **drone_mission_api** enforcing geofencing and mission approval workflows.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 105 | Device SDK | Firmware samples, documentation, certification tests | Device Partnerships | Skill SDK |
+| 106 | Robotics protocol | Spec design, secure channel, safety interlocks | Device Partnerships | Permission broker |
+| 107 | Video analytics | Edge preprocessing, privacy filters, alerting | Device Partnerships | Lightweight models |
+| 108 | Automotive support | Voice UX, compliance, connectivity tests | Device Partnerships | Voice assistant |
+| 109 | Smart office | IoT integrations, scheduling sync, policy checks | Device Partnerships | Hybrid router |
+| 110 | Medical devices | Data ingestion, compliance audits, alerting | Device Partnerships | Security reviews |
+| 111 | Smart home | Automation builder, machine learning loops, UX | Device Partnerships | Smart sync |
+| 112 | Drone API | Geofence enforcement, mission planner integration | Device Partnerships | Robotics protocol |
+
+### Validation & Rollout
+- Certification with two launch partners; automotive integration passes OEM review; drone API passes flight simulator tests.
+- Wave D focus with staged partner onboardings.
+
+## 10. Developer Ecosystem (113–120)
+
+### Architecture & Components
+- Launch **developer_portal** (Docusaurus) with documentation, API explorer, sandbox key issuance.
+- Ship **visual_skill_editor** enabling low-code skill composition with validation.
+- Implement **skill_certification_program** with automated assessment rubrics and badge issuance.
+- Integrate **auto_code_review_bot** leveraging ML suggestions for skill repositories.
+- Publish **domain_dataset_catalog** with curated datasets, licensing, and download tooling.
+- Build **author_analytics_dashboard** tracking conversion, retention, revenue metrics.
+- Coordinate **innovation_events_platform** for hackathons, challenges, leaderboard.
+- Provide **ci_cd_integrations** (GitHub Actions, GitLab CI) templates with deployment hooks.
+
+### Implementation Backlog
+| Item | Capability | Key Tasks | Owner | Dependencies |
+| --- | --- | --- | --- | --- |
+| 113 | Developer portal | Docs IA, sandbox key issuance, login | DevRel | Identity |
+| 114 | Visual editor | Graphical composer, validation, export | DevRel | Skill chain composer |
+| 115 | Certification | Exam engine, scoring, badge API | DevRel | Developer portal |
+| 116 | Auto code review | ML model integration, PR comments, feedback loop | DevRel | Skill repos |
+| 117 | Dataset catalog | Curation, storage, licensing agreements | Data Learning | Legal |
+| 118 | Analytics panel | KPI pipeline, dashboard, alerting | DevRel | Marketplace analytics |
+| 119 | Hackathons/challenges | Event tooling, prize management, tracking | DevRel | Partner program |
+| 120 | CI/CD integrations | Templates, documentation, webhook automation | DevRel | Config registry |
+
+### Validation & Rollout
+- Portal NPS >70; certification cohort throughput >100 developers/quarter; CI/CD templates adopted by ≥50 partner repos.
+- Wave D execution with phased launches aligned to partner readiness.
+
+## Cross-Cutting Testing & Observability
+
+- **Security:** Every new service integrated with dynamic policy enforcement, vulnerability scanning, and penetration testing.
+- **Telemetry:** Mandatory traces/logs linked to action journal IDs; dashboards built in Grafana; alerts in PagerDuty.
+- **QA Strategy:** Unit/integration tests per service, end-to-end mission runs in simulation hub, shadow-mode releases prior to GA.
+
+## Reporting & KPIs
+
+- Weekly status reviews track percent completion per item, blocker status, and KPI deltas.
+- Post-launch metrics feed into executive scorecard (marketplace GMV, planner productivity lift, annotation efficiency, UX
+  adoption, performance cost savings, edge usage, device partner activation, developer engagement).
+


### PR DESCRIPTION
## Summary
- replace the phase 2 roadmap with an execution blueprint that maps capabilities 41-120 to concrete services, deliverables, and owners
- add detailed architecture notes, implementation backlogs, validation gates, and rollout sequencing for each capability cluster

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cf84d8df008323bb0c57941c568429