### PR TITLE
Add config fingerprint snapshot to runtime logs

### DIFF
--- a/backend/include/config.h
+++ b/backend/include/config.h
@@ -11,8 +11,13 @@ typedef struct {
     double eff_threshold;
     double max_complexity;
     uint64_t seed;
+    char source_path[256];
+    bool loaded_from_file;
+    char canonical_json[256];
+    char fingerprint[65];
 } kolibri_config_t;
 
 bool kolibri_load_config(kolibri_config_t* cfg, const char* json_path);
+bool kolibri_config_write_snapshot(const kolibri_config_t* cfg, const char* path);
 
 #endif

--- a/backend/include/reason.h
+++ b/backend/include/reason.h
@@ -13,6 +13,7 @@ typedef struct {
     double bench_eff[10];
     char memory[256];
     char fmt[16];
+    char config_fingerprint[65];
     double eff, compl;
     char prev[65];
     char merkle[65];
@@ -21,7 +22,7 @@ typedef struct {
 } ReasonBlock;
 
 /* Build canonical JSON payload (without hash/hmac), into buf.
-   Order: step,parent,seed,fmt,formula,param_count,params,eff,compl,prev,votes (10),
+   Order: step,parent,seed,config_fingerprint,fmt,formula,param_count,params,eff,compl,prev,votes (10),
           vote_softmax,vote_median,bench (10),memory,merkle
    Floats: %.17g
    No spaces anywhere.

--- a/backend/src/chainio.c
+++ b/backend/src/chainio.c
@@ -50,6 +50,16 @@ bool chain_load(const char* path, ReasonBlock** out_arr, size_t* out_n){
         if(sscanf(line, "{\"step\":%llu", &tmp)==1) b->step=(uint64_t)tmp;
         char* p=strstr(line,"\"parent\":"); if(p && sscanf(p,"\"parent\":%llu",&tmp)==1) b->parent=(uint64_t)tmp;
         p=strstr(line,"\"seed\":"); if(p && sscanf(p,"\"seed\":%llu",&tmp)==1) b->seed=(uint64_t)tmp;
+        p=strstr(line,"\"config_fingerprint\":\"");
+        if(p){
+            p+=strlen("\"config_fingerprint\":\"");
+            size_t j=0;
+            while(*p && *p!='"' && j<sizeof(b->config_fingerprint)-1){
+                if(*p=='\\' && p[1]) p++;
+                b->config_fingerprint[j++]=*p++;
+            }
+            b->config_fingerprint[j]=0;
+        }
         p=strstr(line,"\"fmt\":\"");
         if(p){ p+=strlen("\"fmt\":\""); size_t j=0; while(*p && *p!='"' && j<sizeof(b->fmt)-1){ if(*p=='\\'&&p[1]) p++; b->fmt[j++]=*p++; } b->fmt[j]=0; }
         p=strstr(line,"\"formula\":\"");

--- a/backend/src/config.c
+++ b/backend/src/config.c
@@ -1,7 +1,64 @@
 #include "config.h"
+#include <openssl/sha.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+static void hex_encode(const unsigned char* in, size_t n, char* out){
+    static const char* h="0123456789abcdef";
+    for(size_t i=0;i<n;i++){
+        out[2*i]=h[(in[i]>>4)&0xF];
+        out[2*i+1]=h[in[i]&0xF];
+    }
+    out[2*n]=0;
+}
+
+static int write_canonical_json(const kolibri_config_t* c, char* buf, size_t n){
+    return snprintf(
+        buf,
+        n,
+        "{\"depth_decay\":%.17g,\"depth_max\":%d,\"eff_threshold\":%.17g,"
+        "\"max_complexity\":%.17g,\"quorum\":%.17g,\"seed\":%llu,"
+        "\"steps\":%d,\"temperature\":%.17g}",
+        c->depth_decay,
+        c->depth_max,
+        c->eff_threshold,
+        c->max_complexity,
+        c->quorum,
+        (unsigned long long)c->seed,
+        c->steps,
+        c->temperature);
+}
+
+static void refresh_fingerprint(kolibri_config_t* c){
+    char canonical[sizeof(c->canonical_json)];
+    int len = write_canonical_json(c, canonical, sizeof(canonical));
+    if(len < 0 || (size_t)len >= sizeof(canonical)){
+        c->canonical_json[0] = 0;
+        c->fingerprint[0] = 0;
+        return;
+    }
+    memcpy(c->canonical_json, canonical, (size_t)len + 1);
+    unsigned char digest[SHA256_DIGEST_LENGTH];
+    SHA256((const unsigned char*)canonical, (size_t)len, digest);
+    hex_encode(digest, SHA256_DIGEST_LENGTH, c->fingerprint);
+}
+
+static void json_escape(const char* in, char* out, size_t n){
+    size_t j = 0;
+    if(n == 0){
+        return;
+    }
+    for(size_t i = 0; in && in[i] && j + 2 < n; ++i){
+        if(in[i] == '"' || in[i] == '\\'){
+            out[j++] = '\\';
+        }
+        out[j++] = in[i];
+    }
+    if(j < n){
+        out[j] = 0;
+    }
+}
 
 bool kolibri_load_config(kolibri_config_t* c, const char* json_path){
     c->steps = 30;
@@ -12,15 +69,34 @@ bool kolibri_load_config(kolibri_config_t* c, const char* json_path){
     c->eff_threshold = 0.8;
     c->max_complexity = 32.0;
     c->seed = 987654321ULL;
+    c->loaded_from_file = false;
+    snprintf(c->source_path, sizeof(c->source_path), "<defaults>");
+    c->canonical_json[0] = 0;
+    c->fingerprint[0] = 0;
 
-    if(!json_path) return true;
+    if(!json_path){
+        refresh_fingerprint(c);
+        return true;
+    }
     FILE* f = fopen(json_path,"rb");
-    if(!f) return true;
+    if(!f){
+        refresh_fingerprint(c);
+        return true;
+    }
+    c->loaded_from_file = true;
+    strncpy(c->source_path, json_path, sizeof(c->source_path)-1);
+    c->source_path[sizeof(c->source_path)-1] = 0;
     fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
     char* buf=(char*)malloc(n+1); if(!buf){ fclose(f); return true; }
     size_t readn=fread(buf,1,(size_t)n,f);
     fclose(f);
-    if(readn!=(size_t)n){ free(buf); return true; }
+    if(readn!=(size_t)n){
+        free(buf);
+        c->loaded_from_file = false;
+        snprintf(c->source_path, sizeof(c->source_path), "<defaults>");
+        refresh_fingerprint(c);
+        return true;
+    }
     buf[n]=0;
     char* p=buf;
     #define GETI(k,dst) do{ char* q=strstr(p,k); if(q){ q=strchr(q,':'); if(q){ dst=atoi(q+1);} } }while(0)
@@ -35,5 +111,27 @@ bool kolibri_load_config(kolibri_config_t* c, const char* json_path){
     GETD("\"max_complexity\"", c->max_complexity);
     GETU("\"seed\"", c->seed);
     free(buf);
+    refresh_fingerprint(c);
     return true;
+}
+
+bool kolibri_config_write_snapshot(const kolibri_config_t* cfg, const char* path){
+    if(!cfg || !path || !cfg->canonical_json[0] || !cfg->fingerprint[0]){
+        return false;
+    }
+    FILE* f = fopen(path, "wb");
+    if(!f){
+        return false;
+    }
+    char source_escaped[512];
+    json_escape(cfg->source_path, source_escaped, sizeof(source_escaped));
+    int written = fprintf(
+        f,
+        "{\n  \"source\": \"%s\",\n  \"loaded_from_file\": %s,\n  \"config\": %s,\n  \"fingerprint\": \"%s\"\n}\n",
+        source_escaped,
+        cfg->loaded_from_file ? "true" : "false",
+        cfg->canonical_json,
+        cfg->fingerprint);
+    fclose(f);
+    return written > 0;
 }

--- a/backend/src/core.c
+++ b/backend/src/core.c
@@ -357,6 +357,9 @@ bool kolibri_step(const kolibri_config_t* cfg, int step, const char* prev_hash,
     ensure_bench_data();
     memset(out,0,sizeof(*out));
     out->step=step; out->parent=(step>0)?(step-1):0; out->seed=cfg->seed^((uint64_t)step);
+    if(cfg->fingerprint[0]){
+        snprintf(out->config_fingerprint, sizeof(out->config_fingerprint), "%s", cfg->fingerprint);
+    }
     strncpy(out->fmt, "dsl-v1", sizeof(out->fmt)-1);
 
 

--- a/backend/src/main_run.c
+++ b/backend/src/main_run.c
@@ -18,6 +18,10 @@ int main(int argc, char** argv){
     kolibri_config_t cfg; kolibri_load_config(&cfg, cfg_path);
 
     ensure_logs_dir();
+    /* Config registry snapshot (Phase 2 roadmap item 95). */
+    if(!kolibri_config_write_snapshot(&cfg, "logs/config_snapshot.json")){
+        fprintf(stderr, "[WARN] unable to write config snapshot registry\n");
+    }
     char prev[65]={0}, hash[65]={0};
     for(int step=1; step<=cfg.steps; ++step){
         ReasonBlock b={0};

--- a/backend/src/reason.c
+++ b/backend/src/reason.c
@@ -19,11 +19,13 @@ int rb_payload_json(const ReasonBlock* b, char* buf, size_t n){
     char fmtesc[64]; esc(b->fmt, fmtesc, sizeof(fmtesc));
     char prev_esc[128]; esc(b->prev, prev_esc, sizeof(prev_esc));
     char merkle_esc[128]; esc(b->merkle, merkle_esc, sizeof(merkle_esc));
+    char cfgfp_esc[128]; esc(b->config_fingerprint, cfgfp_esc, sizeof(cfgfp_esc));
     int off=0;
     off += snprintf(buf+off, n-off, "{\"step\":%llu,\"parent\":%llu,\"seed\":%llu,",
                     (unsigned long long)b->step,
                     (unsigned long long)b->parent,
                     (unsigned long long)b->seed);
+    off += snprintf(buf+off, n-off, "\"config_fingerprint\":\"%s\",", cfgfp_esc);
     off += snprintf(buf+off, n-off, "\"fmt\":\"%s\",\"formula\":\"%s\",", fmtesc, fesc);
     off += snprintf(buf+off, n-off, "\"param_count\":%d,\"params\":[", b->param_count);
     for(int i=0;i<b->param_count;i++){

--- a/backend/tests/reason_payload_test.c
+++ b/backend/tests/reason_payload_test.c
@@ -7,6 +7,7 @@ int main(void){
     b.step = 42;
     b.parent = 21;
     b.seed = 7;
+    strncpy(b.config_fingerprint, "deadbeef", sizeof(b.config_fingerprint)-1);
     b.eff = 0.25;
     b.compl = 0.75;
     strncpy(b.formula, "a+b", sizeof(b.formula)-1);

--- a/docs/phase2_capabilities_roadmap.md
+++ b/docs/phase2_capabilities_roadmap.md
@@ -218,6 +218,9 @@ with explicit dependencies, but each table can feed directly into a backlog tool
 | 95 | Config registry | Manifest schema, CLI tools, rollback workflows | Platform Ops | GitOps |
 | 96 | Zero-downtime releases | Canary orchestration, traffic shadowing, rollback automation | Platform Ops | Config registry |
 
+- **Runtime progress (config registry #95):** `kolibri_run` now writes `logs/config_snapshot.json` with the canonical
+  configuration JSON and SHA-256 fingerprint for each execution, seeding the manifest ledger for future diff tooling.
+
 ### Validation & Rollout
 - Latency reduction ≥20%; cost overrun alerts triggered in staging tests; canary release success rate ≥99%.
 - Wave B: 89–92 GA. Wave C: 93–96 GA.

--- a/tests/test_reason_payload.py
+++ b/tests/test_reason_payload.py
@@ -19,6 +19,7 @@ def main() -> None:
         "step",
         "parent",
         "seed",
+        "config_fingerprint",
         "formula",
         "eff",
         "compl",


### PR DESCRIPTION
## Summary
- compute a canonical JSON manifest and SHA-256 fingerprint whenever kolibri loads configuration
- persist the config fingerprint in logged reason blocks and emit a config snapshot registry file for each run
- document the new runtime snapshot in the phase 2 roadmap to track progress on item 95

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68cf8f9c919483239d6efe16ba421dec