### PR TITLE
Add Kolibri chat CLI

### DIFF
--- a/docs/runtime_and_operations.md
+++ b/docs/runtime_and_operations.md
@@ -79,7 +79,9 @@ sandbox.register("echo", lambda payload: {"text": payload["goal"].upper()})
 
 runtime = KolibriRuntime(sandbox=sandbox)
 runtime.privacy.grant("demo", ["text"])
-response = runtime.process(RuntimeRequest(user_id="demo", goal="echo", modalities={"text": "hello"}))
+response = runtime.process(
+    RuntimeRequest(user_id="demo", goal="echo", modalities={"text": "hello"})
+)
 print(response.answer["summary"])
 ```
 
@@ -90,16 +92,37 @@ print(response.answer["summary"])
 
 ### Консольный чат
 
-- Для быстрой проверки региструйте sandbox-навыки через новый CLI:
+1. Активируйте Python-окружение с установленным пакетом `kolibri_x`
+   (например, `pip install -e .`).
+2. Запустите CLI, указав идентификатор пользователя, которому нужно выдать
+   доступ к текстовой модальности:
 
-  ```bash
-  python -m kolibri_x.cli.chat --user-id demo
-  ```
+   ```bash
+   python -m kolibri_x.cli.chat --user-id demo
+   ```
 
-- Поддерживаются команды `:journal`, `:reason`, `:quit`. Команда `:journal`
-  выводит последние события `ActionJournal`, `:reason` — текущий `ReasoningLog`.
-  Перед запуском можно прогрузить знания в граф аргументом
-  `--knowledge path/to/file_or_dir`.
+3. При необходимости передайте аргумент `--knowledge`, чтобы сразу загрузить
+   документы в граф знаний до начала диалога. CLI принимает как путь к файлу,
+   так и директорию:
+
+   ```bash
+   python -m kolibri_x.cli.chat --user-id demo --knowledge docs/primer.txt
+   ```
+
+4. После запуска введите сообщение — runtime сформирует план, выполнит
+   sandbox-навык по умолчанию и покажет суммарный ответ. Доступны специальные
+   команды:
+
+   - `:journal` — вывести последние события `ActionJournal`.
+   - `:reason` — распечатать `ReasoningLog` текущего ответа в формате JSON.
+   - `:quit` — завершить сессию.
+
+   Все команды работают в одном цикле, поэтому можно чередовать пользовательские
+   сообщения и отладочные запросы.
+
+По умолчанию CLI регистрирует sandbox-навык `chat_responder` без дополнительных
+разрешений. При необходимости замените обработчик в `kolibri_x/cli/chat.py`,
+чтобы перенаправлять запросы в собственные навыки или внешние сервисы.
 
 ## Офлайн-режим
 

--- a/docs/runtime_and_operations.md
+++ b/docs/runtime_and_operations.md
@@ -70,21 +70,36 @@
 
 Для интеграции Python-компонентов используйте `KolibriRuntime`:
 
-```python
+-```python
 from kolibri_x.runtime.orchestrator import KolibriRuntime, RuntimeRequest
 from kolibri_x.runtime.orchestrator import SkillSandbox
 
 sandbox = SkillSandbox()
-sandbox.register("echo", lambda payload: {"text": payload["text"].upper()})
+sandbox.register("echo", lambda payload: {"text": payload["goal"].upper()})
 
 runtime = KolibriRuntime(sandbox=sandbox)
-response = runtime.execute(RuntimeRequest(user_id="demo", goal="echo", modalities={"text": "hello"}))
-print(response.answer)
+runtime.privacy.grant("demo", ["text"])
+response = runtime.process(RuntimeRequest(user_id="demo", goal="echo", modalities={"text": "hello"}))
+print(response.answer["summary"])
 ```
 
 - Конфигурация runtime описана в [architecture](architecture.md).
 - Все внешние навыки должны регистрироваться в `SkillStore` или напрямую в
-  `SkillSandbox` (для тестов).
+  `SkillSandbox` (для тестов). Перед первым запросом выдавайте пользователю
+  разрешения на необходимые модальности через `runtime.privacy.grant`.
+
+### Консольный чат
+
+- Для быстрой проверки региструйте sandbox-навыки через новый CLI:
+
+  ```bash
+  python -m kolibri_x.cli.chat --user-id demo
+  ```
+
+- Поддерживаются команды `:journal`, `:reason`, `:quit`. Команда `:journal`
+  выводит последние события `ActionJournal`, `:reason` — текущий `ReasoningLog`.
+  Перед запуском можно прогрузить знания в граф аргументом
+  `--knowledge path/to/file_or_dir`.
 
 ## Офлайн-режим
 

--- a/kolibri_x/cli/__init__.py
+++ b/kolibri_x/cli/__init__.py
@@ -1,0 +1,3 @@
+"""Command-line tools for interacting with Kolibri runtime."""
+
+__all__ = ["chat"]

--- a/kolibri_x/cli/chat.py
+++ b/kolibri_x/cli/chat.py
@@ -1,0 +1,231 @@
+"""Console chat interface built on top of :mod:`kolibri_x.runtime`."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Iterable, List, Mapping, Optional, Sequence
+
+from kolibri_x.kg.ingest import KnowledgeDocument
+from kolibri_x.runtime.cache import OfflineCache
+from kolibri_x.runtime.journal import JournalEntry, ActionJournal
+from kolibri_x.runtime.orchestrator import (
+    KolibriRuntime,
+    RuntimeRequest,
+    RuntimeResponse,
+    SkillExecution,
+    SkillSandbox,
+)
+from kolibri_x.skills.store import SkillManifest, SkillStore
+
+CHAT_SKILL_NAME = "chat_responder"
+DEFAULT_USER_ID = "cli-user"
+
+
+def _default_chat_executor(payload: Mapping[str, object]) -> Mapping[str, object]:
+    goal = str(payload.get("goal", "")).strip()
+    step = str(payload.get("step", "")).strip()
+    modalities = payload.get("modalities", [])
+    focus = goal or step or "your request"
+    return {
+        "reply": f"Kolibri: I considered '{focus}'",
+        "modalities": list(modalities),
+    }
+
+
+def build_runtime(*, user_id: str = DEFAULT_USER_ID) -> KolibriRuntime:
+    """Construct a runtime preconfigured for conversational experiments."""
+
+    skill_store = SkillStore()
+    manifest = SkillManifest.from_dict(
+        {
+            "name": CHAT_SKILL_NAME,
+            "version": "0.1.0",
+            "inputs": ["text"],
+            "permissions": [],
+            "billing": "per_call",
+            "policy": {},
+            "entry": "chat.py",
+        }
+    )
+    skill_store.register(manifest)
+
+    sandbox = SkillSandbox()
+    sandbox.register(CHAT_SKILL_NAME, _default_chat_executor)
+
+    cache = OfflineCache(ttl=timedelta(minutes=15))
+    journal = ActionJournal()
+    runtime = KolibriRuntime(skill_store=skill_store, sandbox=sandbox, cache=cache, journal=journal)
+    runtime.privacy.grant(user_id, ["text"])
+    return runtime
+
+
+@dataclass
+class ChatSession:
+    runtime: KolibriRuntime
+    user_id: str = DEFAULT_USER_ID
+    journal_tail: int = 5
+    last_response: Optional[RuntimeResponse] = None
+
+    def handle_message(self, message: str) -> str:
+        text = message.strip()
+        if not text:
+            return "Введите сообщение для Kolibri."
+        if text.startswith(":"):
+            return self._handle_command(text[1:])
+
+        request = RuntimeRequest(user_id=self.user_id, goal=text, modalities={"text": text})
+        response = self.runtime.process(request)
+        self.last_response = response
+
+        parts: List[str] = []
+        summary = response.answer.get("summary")
+        if summary:
+            parts.append(str(summary))
+        else:
+            parts.append("Kolibri не вернула краткое описание ответа.")
+
+        parts.extend(self._format_executions(response.executions))
+        parts.extend(self._format_journal(self.runtime.journal.tail(self.journal_tail)))
+        return "\n".join(parts)
+
+    def _handle_command(self, command: str) -> str:
+        key = command.strip().lower()
+        if key in {"quit", "exit"}:
+            raise SystemExit(0)
+        if key == "journal":
+            tail = [entry.to_dict() for entry in self.runtime.journal.tail(self.journal_tail)]
+            if not tail:
+                return "Журнал пуст."
+            return json.dumps(tail, ensure_ascii=False, indent=2)
+        if key == "reason":
+            if not self.last_response:
+                return "Нет доступного лога рассуждений."
+            return self.last_response.reasoning.to_json()
+        return f"Неизвестная команда: :{command}"
+
+    def _format_executions(self, executions: Sequence[SkillExecution]) -> List[str]:
+        if not executions:
+            return ["Навыковая часть плана не была выполнена."]
+        lines = ["Шаги навыков:"]
+        for execution in executions:
+            lines.append(self._describe_execution(execution))
+        return lines
+
+    def _describe_execution(self, execution: SkillExecution) -> str:
+        skill = execution.skill or "<none>"
+        status = str(execution.output.get("status", "unknown"))
+        if status == "ok":
+            result = execution.output.get("result", {})
+            if isinstance(result, Mapping):
+                reply = result.get("reply") or result.get("draft") or result.get("message")
+            else:
+                reply = result
+            detail = f" — {reply}" if reply else ""
+            return f"- {skill}: выполнен{detail}"
+        if status == "policy_blocked":
+            policy = execution.output.get("policy")
+            reason = execution.output.get("reason")
+            detail = f" (политика: {policy})" if policy else ""
+            if reason:
+                detail += f" — {reason}"
+            return f"- {skill}: заблокирован политикой{detail}"
+        if status == "error":
+            message = execution.output.get("message", "неизвестная ошибка")
+            return f"- {skill}: ошибка — {message}"
+        return f"- {skill}: статус {status}"
+
+    def _format_journal(self, entries: Sequence[JournalEntry]) -> List[str]:
+        if not entries:
+            return ["Журнал пуст."]
+        lines = ["Журнал (последние события):"]
+        for entry in entries:
+            lines.append(f"- #{entry.index} {entry.event}")
+        return lines
+
+
+def _iter_knowledge_paths(path: Path) -> Iterable[Path]:
+    if path.is_file():
+        yield path
+        return
+    if path.is_dir():
+        for candidate in sorted(p for p in path.rglob("*") if p.is_file()):
+            yield candidate
+
+
+def _ingest_paths(runtime: KolibriRuntime, paths: Sequence[str]) -> None:
+    for raw in paths:
+        current = Path(raw).expanduser().resolve()
+        if not current.exists():
+            print(f"[ingest] путь не найден: {raw}")
+            continue
+        for file_path in _iter_knowledge_paths(current):
+            try:
+                content = file_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                print(f"[ingest] ошибка чтения {file_path}: {exc}")
+                continue
+            document = KnowledgeDocument(
+                doc_id=f"cli::{file_path.stem}",
+                source=str(file_path),
+                title=file_path.stem,
+                content=content,
+                tags=("cli",),
+            )
+            report = runtime.ingest_document(document)
+            print(
+                "[ingest]", file_path,
+                f"nodes={report.nodes_added}",
+                f"edges={report.edges_added}",
+                f"conflicts={len(report.conflicts)}",
+                f"warnings={len(report.warnings)}",
+            )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Chat with KolibriRuntime")
+    parser.add_argument("--user-id", default=DEFAULT_USER_ID, help="identifier for the chat user")
+    parser.add_argument(
+        "--knowledge",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="path to a knowledge file or directory to ingest before chatting",
+    )
+    parser.add_argument(
+        "--journal-tail",
+        type=int,
+        default=5,
+        help="number of journal entries to display in responses",
+    )
+    args = parser.parse_args(argv)
+
+    runtime = build_runtime(user_id=args.user_id)
+    session = ChatSession(runtime=runtime, user_id=args.user_id, journal_tail=max(1, args.journal_tail))
+
+    if args.knowledge:
+        _ingest_paths(runtime, args.knowledge)
+
+    print("Kolibri CLI chat. Команды: :journal, :reason, :quit")
+    try:
+        while True:
+            try:
+                user_input = input("> ")
+            except EOFError:
+                print()
+                break
+            try:
+                output = session.handle_message(user_input)
+            except SystemExit:
+                print("Выход из чата.")
+                break
+            if output:
+                print(output)
+    except KeyboardInterrupt:
+        print("\nЗавершение по Ctrl+C")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_chat_cli.py
+++ b/tests/test_chat_cli.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kolibri_x.cli.chat import CHAT_SKILL_NAME, ChatSession, build_runtime
+
+
+def test_build_runtime_registers_chat_skill() -> None:
+    runtime = build_runtime(user_id="tester")
+    manifest = runtime.skill_store.get(CHAT_SKILL_NAME)
+    assert manifest is not None
+    assert CHAT_SKILL_NAME in runtime.sandbox.registered()
+    payload = {"goal": "test", "step": "respond", "modalities": ["text"]}
+    result = runtime.sandbox.execute(CHAT_SKILL_NAME, payload)
+    assert result["reply"].startswith("Kolibri: I considered")
+
+
+def test_chat_session_handle_message_returns_summary() -> None:
+    runtime = build_runtime(user_id="tester")
+    session = ChatSession(runtime=runtime, user_id="tester", journal_tail=3)
+    output = session.handle_message("Привет, Kolibri")
+    assert "Шаги навыков:" in output
+    assert CHAT_SKILL_NAME in output
+    assert "Журнал (последние события):" in output
+    assert "Kolibri" in output
+
+    reasoning_log = session.handle_message(":reason")
+    assert "steps" in reasoning_log


### PR DESCRIPTION
## Summary
- add a chat CLI that boots KolibriRuntime with a sandbox skill, chat session helpers, and optional knowledge ingestion
- document the new console entry point and update the runtime usage example to reflect `runtime.process`
- cover the CLI runtime builder and session flow with unit tests

## Testing
- pytest tests/test_chat_cli.py
- pytest tests/test_kolibri_x_pipeline.py::test_runtime_orchestrator_end_to_end

------
https://chatgpt.com/codex/tasks/task_e_68cf9bc229d88323804b633442149c80