### PR TITLE
Refactor verification to use runtime config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SRC := backend/src
 BIN_DIR := bin
 BINS := $(BIN_DIR)/kolibri_run $(BIN_DIR)/kolibri_verify $(BIN_DIR)/kolibri_replay
 
-TEST_BINS := $(BIN_DIR)/reason_payload_test $(BIN_DIR)/bench_validation_test $(BIN_DIR)/fractal_test
+TEST_BINS := $(BIN_DIR)/reason_payload_test $(BIN_DIR)/bench_validation_test $(BIN_DIR)/fractal_test $(BIN_DIR)/test_verify_break
 
 COMMON_OBJS := $(SRC)/digit_agents.c $(SRC)/vote_aggregate.c
 
@@ -61,11 +61,15 @@ $(BIN_DIR)/bench_validation_test: backend/tests/bench_validation_test.c $(SRC)/r
 $(BIN_DIR)/fractal_test: backend/tests/fractal_test.c $(SRC)/fractal.c $(SRC)/dsl.c $(SRC)/reason.c
 	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
 
+$(BIN_DIR)/test_verify_break: backend/tests/test_verify_break.c $(SRC)/chainio.c $(SRC)/reason.c $(SRC)/config.c
+	$(CC) $(CFLAGS) $(INCLUDE) $^ -o $@ $(LDFLAGS)
+
 .PHONY: tests
 tests: $(BIN_DIR) $(TEST_BINS)
 	python3 tests/test_reason_payload.py
 	$(BIN_DIR)/bench_validation_test
 	$(BIN_DIR)/fractal_test
+	$(BIN_DIR)/test_verify_break
 
 .PHONY: test
 test: $(BIN_DIR)/test_vote

--- a/backend/include/chainio.h
+++ b/backend/include/chainio.h
@@ -1,9 +1,10 @@
 #ifndef KOLIBRI_CHAINIO_H
 #define KOLIBRI_CHAINIO_H
+#include "config.h"
 #include "reason.h"
 #include <stdbool.h>
 #include <stdio.h>
-bool chain_append(const char* path, const ReasonBlock* b);
+bool chain_append(const char* path, const ReasonBlock* b, const kolibri_config_t* cfg);
 bool chain_load(const char* path, ReasonBlock** out_arr, size_t* out_n);
-bool chain_verify(const char* path, FILE* out);
+bool chain_verify(const char* path, FILE* out, const kolibri_config_t* cfg);
 #endif

--- a/backend/include/config.h
+++ b/backend/include/config.h
@@ -15,9 +15,14 @@ typedef struct {
     bool loaded_from_file;
     char canonical_json[256];
     char fingerprint[65];
+    char hmac_key[128];
+    char hmac_salt[128];
+    bool has_hmac_key;
+    bool has_hmac_salt;
 } kolibri_config_t;
 
 bool kolibri_load_config(kolibri_config_t* cfg, const char* json_path);
 bool kolibri_config_write_snapshot(const kolibri_config_t* cfg, const char* path);
+const char* kolibri_config_hmac_key(const kolibri_config_t* cfg);
 
 #endif

--- a/backend/src/core.c
+++ b/backend/src/core.c
@@ -444,8 +444,7 @@ bool kolibri_step(const kolibri_config_t* cfg, int step, const char* prev_hash,
 
     char hash_hex[65];
     sha256_hex_local((unsigned char*)payload, (size_t)len, hash_hex);
-    const char* key = getenv("KOLIBRI_HMAC_KEY");
-    if(!key) key = "insecure-key";
+    const char* key = kolibri_config_hmac_key(cfg);
     unsigned char* mac = HMAC(EVP_sha256(), key, (int)strlen(key),
                               (unsigned char*)payload, (size_t)len, NULL, NULL);
     char hmac_hex[65];
@@ -454,7 +453,7 @@ bool kolibri_step(const kolibri_config_t* cfg, int step, const char* prev_hash,
     snprintf(out->hmac, sizeof(out->hmac), "%s", hmac_hex);
     if(out_hash) snprintf(out_hash, 65, "%s", hash_hex);
 
-    if(!chain_append("logs/chain.jsonl", out)){ f_free(f); return false; }
+    if(!chain_append("logs/chain.jsonl", out, cfg)){ f_free(f); return false; }
 
     snprintf(g_last_merkle, sizeof(g_last_merkle), "%s", out->merkle);
 

--- a/backend/src/main_run.c
+++ b/backend/src/main_run.c
@@ -33,7 +33,7 @@ int main(int argc, char** argv){
                step, b.eff, b.compl, b.formula, hash);
         strncpy(prev, hash, 65);
     }
-    if(!chain_verify("logs/chain.jsonl", stdout)){
+    if(!chain_verify("logs/chain.jsonl", stdout, &cfg)){
         fprintf(stderr, "self-check verification failed\n");
         return 1;
     }

--- a/backend/src/main_verify.c
+++ b/backend/src/main_verify.c
@@ -1,10 +1,47 @@
 #include "chainio.h"
+#include "config.h"
 #include "reason.h"
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+static void print_usage(const char* prog){
+    fprintf(stderr,
+            "Usage: %s [--config PATH] [CHAIN_PATH]\n"
+            "  --config PATH   Path to runtime configuration (default: configs/kolibri.json)\n"
+            "  CHAIN_PATH      Path to chain log (default: logs/chain.jsonl)\n",
+            prog);
+}
+
 int main(int argc, char** argv){
-    const char* path = (argc>1)? argv[1] : "logs/chain.jsonl";
-    if(chain_verify(path, stdout)) return 0;
+    const char* chain_path = "logs/chain.jsonl";
+    const char* config_path = "configs/kolibri.json";
+    bool chain_arg_consumed = false;
+
+    for(int i = 1; i < argc; ++i){
+        if(strcmp(argv[i], "--config") == 0){
+            if(i + 1 >= argc){
+                fprintf(stderr, "--config requires a path argument\n");
+                print_usage(argv[0]);
+                return 1;
+            }
+            config_path = argv[++i];
+        } else if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0){
+            print_usage(argv[0]);
+            return 0;
+        } else if(!chain_arg_consumed){
+            chain_path = argv[i];
+            chain_arg_consumed = true;
+        } else {
+            fprintf(stderr, "Unexpected argument: %s\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    kolibri_config_t cfg;
+    kolibri_load_config(&cfg, config_path);
+    if(chain_verify(chain_path, stdout, &cfg)) return 0;
     return 1;
 }

--- a/backend/tests/test_verify_break.c
+++ b/backend/tests/test_verify_break.c
@@ -1,0 +1,93 @@
+#ifndef _WIN32
+#define _POSIX_C_SOURCE 200809L
+#endif
+#include "chainio.h"
+#include "config.h"
+#include "reason.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
+#include <unistd.h>
+#endif
+
+static void make_temp_path(char* buf, size_t n){
+#ifdef _WIN32
+    if(_tmpnam_s(buf, n) != 0){
+        fprintf(stderr, "_tmpnam_s failed\n");
+        exit(1);
+    }
+#else
+    char tmpl[] = "/tmp/kolibri_verify_XXXXXX";
+    if(n < sizeof(tmpl)){
+        fprintf(stderr, "buffer too small for temp path\n");
+        exit(1);
+    }
+    int fd = mkstemp(tmpl);
+    if(fd < 0){
+        perror("mkstemp");
+        exit(1);
+    }
+    close(fd);
+    if(remove(tmpl) != 0){
+        perror("remove");
+        exit(1);
+    }
+    strncpy(buf, tmpl, n - 1);
+    buf[n - 1] = 0;
+#endif
+}
+
+static void init_block(ReasonBlock* b){
+    memset(b, 0, sizeof(*b));
+    b->step = 1;
+    b->parent = 0;
+    b->seed = 12345;
+    snprintf(b->config_fingerprint, sizeof(b->config_fingerprint), "test-fp");
+    snprintf(b->fmt, sizeof(b->fmt), "test");
+    snprintf(b->formula, sizeof(b->formula), "x+1");
+    b->eff = 0.5;
+    b->compl = 1.0;
+}
+
+int main(void){
+    char path[256];
+    make_temp_path(path, sizeof(path));
+
+    ReasonBlock block;
+    init_block(&block);
+
+    kolibri_config_t good_cfg;
+    kolibri_load_config(&good_cfg, NULL);
+    snprintf(good_cfg.hmac_key, sizeof(good_cfg.hmac_key), "verify-key-%ld", (long)getpid());
+    good_cfg.has_hmac_key = true;
+
+    if(!chain_append(path, &block, &good_cfg)){
+        fprintf(stderr, "chain_append failed\n");
+        remove(path);
+        return 1;
+    }
+
+    if(!chain_verify(path, NULL, &good_cfg)){
+        fprintf(stderr, "expected verification success with matching config\n");
+        remove(path);
+        return 1;
+    }
+
+    kolibri_config_t bad_cfg = good_cfg;
+    snprintf(bad_cfg.hmac_key, sizeof(bad_cfg.hmac_key), "verify-key-bad-%ld", (long)getpid());
+    bad_cfg.has_hmac_key = true;
+
+    if(chain_verify(path, NULL, &bad_cfg)){
+        fprintf(stderr, "expected verification failure with mismatched key\n");
+        remove(path);
+        return 1;
+    }
+
+    remove(path);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend the runtime config structure to carry HMAC credentials and expose a helper that returns the active key
- thread the loaded configuration through chain append/verify routines and update the CLI to accept a `--config` flag
- add a regression test that exercises verification with matching and mismatched HMAC keys and wire it into `make tests`

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68cfcde320c88323ba1d569459563807