### PR TITLE
fix: dynamically resolve chat API base

### DIFF
--- a/smart_client/frontend/src/state/useChatStore.ts
+++ b/smart_client/frontend/src/state/useChatStore.ts
@@ -49,7 +49,111 @@ const randomId = () => {
   return Math.random().toString(36).slice(2);
 };
 
-const API_BASE = "";
+const KNOWN_APP_ROUTES = new Set(["chat", "ledger", "settings"]);
+
+let resolvedApiBase: string | null = null;
+let resolvingApiBase: Promise<string> | null = null;
+
+function normalizeBase(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return "";
+  }
+  if (/^(?:[a-z]+:)?\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+async function ensureApiBase(): Promise<string> {
+  if (resolvedApiBase !== null) {
+    return resolvedApiBase;
+  }
+  if (!resolvingApiBase) {
+    resolvingApiBase = resolveApiBase();
+  }
+  resolvedApiBase = await resolvingApiBase;
+  return resolvedApiBase;
+}
+
+function inferBaseFromLocation(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const trimmedPath = window.location.pathname.replace(/\/+$/, "");
+  if (!trimmedPath || trimmedPath === "/") {
+    return "";
+  }
+
+  const segments = trimmedPath.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return "";
+  }
+
+  const lastSegment = segments[segments.length - 1];
+  if (lastSegment.includes(".") || KNOWN_APP_ROUTES.has(lastSegment)) {
+    segments.pop();
+  }
+
+  if (segments.length === 0) {
+    return "";
+  }
+
+  return `/${segments.join("/")}`;
+}
+
+async function resolveApiBase(): Promise<string> {
+  const candidates = resolveApiBaseCandidates();
+  for (const base of candidates) {
+    try {
+      const response = await fetch(`${base}/api/v1/status`, { method: "GET" });
+      if (response.ok) {
+        return base;
+      }
+    } catch (error) {
+      console.warn(`Kolibri API base candidate failed: ${base}`, error);
+    }
+  }
+  return candidates[candidates.length - 1] ?? "";
+}
+
+function resolveApiBaseCandidates(): string[] {
+  const candidates: string[] = [];
+
+  const addCandidate = (value: string) => {
+    if (!value || candidates.includes(value)) {
+      return;
+    }
+    candidates.push(value);
+  };
+
+  addCandidate(normalizeBase(import.meta.env.VITE_API_BASE ?? ""));
+
+  if (typeof window !== "undefined") {
+    const globalWithApiBase = window as Window & {
+      __KOLIBRI_API_BASE__?: string;
+      __kolibriApiBase?: string;
+    };
+    addCandidate(
+      normalizeBase(
+        globalWithApiBase.__KOLIBRI_API_BASE__ ?? globalWithApiBase.__kolibriApiBase ?? ""
+      )
+    );
+
+    const meta = document
+      .querySelector('meta[name="kolibri-api-base"]')
+      ?.getAttribute("content");
+    addCandidate(normalizeBase(meta ?? ""));
+
+    addCandidate(normalizeBase(import.meta.env.BASE_URL ?? ""));
+    addCandidate(inferBaseFromLocation());
+  }
+
+  addCandidate("");
+
+  return candidates;
+}
 
 export const useChatStore = create<ChatState>()(
   persist(
@@ -72,92 +176,99 @@ export const useChatStore = create<ChatState>()(
         existingChatStream?.close();
         existingChainStream?.close();
 
-        const chatStream = new EventSource(
-          `${API_BASE}/api/v1/chat/stream?session_id=${sessionId}`
-        );
-        chatStream.onmessage = () => {};
-        let currentAssistantId: string | null = null;
-        chatStream.addEventListener("token", event => {
-          const data = JSON.parse((event as MessageEvent).data) as { content: string };
-          set(state => {
-            const messages = [...state.messages];
-            if (!currentAssistantId) {
-              currentAssistantId = randomId();
-              messages.push({
-                id: currentAssistantId,
-                role: "assistant",
-                content: "",
-                pending: true
+        void ensureApiBase()
+          .then(apiBase => {
+            const chatStream = new EventSource(
+              `${apiBase}/api/v1/chat/stream?session_id=${sessionId}`
+            );
+            chatStream.onmessage = () => {};
+            let currentAssistantId: string | null = null;
+            chatStream.addEventListener("token", event => {
+              const data = JSON.parse((event as MessageEvent).data) as { content: string };
+              set(state => {
+                const messages = [...state.messages];
+                if (!currentAssistantId) {
+                  currentAssistantId = randomId();
+                  messages.push({
+                    id: currentAssistantId,
+                    role: "assistant",
+                    content: "",
+                    pending: true
+                  });
+                }
+                const idx = messages.findIndex(msg => msg.id === currentAssistantId);
+                if (idx >= 0) {
+                  messages[idx] = {
+                    ...messages[idx],
+                    content: `${messages[idx].content}${data.content}`
+                  };
+                }
+                return { messages };
               });
-            }
-            const idx = messages.findIndex(msg => msg.id === currentAssistantId);
-            if (idx >= 0) {
-              messages[idx] = {
-                ...messages[idx],
-                content: `${messages[idx].content}${data.content}`
-              };
-            }
-            return { messages };
-          });
-        });
-        chatStream.addEventListener("tool_call", event => {
-          const data = JSON.parse((event as MessageEvent).data);
-          set(state => ({
-            messages: [
-              ...state.messages,
-              {
-                id: randomId(),
-                role: "tool",
-                content: JSON.stringify(data, null, 2),
-                toolName: data.name
-              }
-            ]
-          }));
-        });
-        chatStream.addEventListener("final", event => {
-          const data = JSON.parse((event as MessageEvent).data) as { content: string };
-          set(state => {
-            const messages = [...state.messages];
-            if (currentAssistantId) {
-              const idx = messages.findIndex(msg => msg.id === currentAssistantId);
-              if (idx >= 0) {
-                messages[idx] = {
-                  ...messages[idx],
-                  content: data.content,
-                  pending: false,
-                  sources: extractSources(data.content)
-                };
-              }
-            } else {
-              messages.push({
-                id: randomId(),
-                role: "assistant",
-                content: data.content,
-                pending: false,
-                sources: extractSources(data.content)
+            });
+            chatStream.addEventListener("tool_call", event => {
+              const data = JSON.parse((event as MessageEvent).data);
+              set(state => ({
+                messages: [
+                  ...state.messages,
+                  {
+                    id: randomId(),
+                    role: "tool",
+                    content: JSON.stringify(data, null, 2),
+                    toolName: data.name
+                  }
+                ]
+              }));
+            });
+            chatStream.addEventListener("final", event => {
+              const data = JSON.parse((event as MessageEvent).data) as { content: string };
+              set(state => {
+                const messages = [...state.messages];
+                if (currentAssistantId) {
+                  const idx = messages.findIndex(msg => msg.id === currentAssistantId);
+                  if (idx >= 0) {
+                    messages[idx] = {
+                      ...messages[idx],
+                      content: data.content,
+                      pending: false,
+                      sources: extractSources(data.content)
+                    };
+                  }
+                } else {
+                  messages.push({
+                    id: randomId(),
+                    role: "assistant",
+                    content: data.content,
+                    pending: false,
+                    sources: extractSources(data.content)
+                  });
+                }
+                currentAssistantId = null;
+                return { messages };
               });
-            }
-            currentAssistantId = null;
-            return { messages };
+            });
+
+            const chainStream = new EventSource(`${apiBase}/api/v1/chain/stream`);
+            chainStream.addEventListener("block", event => {
+              const data = JSON.parse((event as MessageEvent).data);
+              set(state => ({
+                chain: [
+                  {
+                    id: data.id,
+                    timestamp: data.timestamp,
+                    payload: data.payload
+                  },
+                  ...state.chain
+                ].slice(0, 50)
+              }));
+            });
+
+            set({ connected: true, chatStream, chainStream });
+          })
+          .catch(error => {
+            console.error("Kolibri chat stream connection failed", error);
+            set({ connected: false, chatStream: null, chainStream: null });
           });
-        });
-
-        const chainStream = new EventSource(`${API_BASE}/api/v1/chain/stream`);
-        chainStream.addEventListener("block", event => {
-          const data = JSON.parse((event as MessageEvent).data);
-          set(state => ({
-            chain: [
-              {
-                id: data.id,
-                timestamp: data.timestamp,
-                payload: data.payload
-              },
-              ...state.chain
-            ].slice(0, 50)
-          }));
-        });
-
-        set({ connected: true, chatStream, chainStream });
       },
       sendMessage: async content => {
         const { sessionId } = get();
@@ -169,7 +280,8 @@ export const useChatStore = create<ChatState>()(
         };
         set(state => ({ messages: [...state.messages, message] }));
         try {
-          await fetch(`${API_BASE}/api/v1/chat`, {
+          const apiBase = await ensureApiBase();
+          await fetch(`${apiBase}/api/v1/chat`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ session_id: sessionId, message: content })
@@ -180,6 +292,7 @@ export const useChatStore = create<ChatState>()(
               msg.id === message.id ? { ...msg, pending: true } : msg
             )
           }));
+          console.error("Kolibri chat request failed", error);
         }
       },
       setView: view => set({ activeView: view }),


### PR DESCRIPTION
## Summary
- probe configured, global, meta, base-url, and inferred prefixes to detect a reachable API base before connecting the chat client
- wait for the resolved API base when opening the SSE streams or sending chat messages and log failures to aid debugging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff435d7208323b7481dad4a545681