### PR TITLE
fix: detect versioned API root

### DIFF
--- a/smart_client/frontend/src/state/useChatStore.ts
+++ b/smart_client/frontend/src/state/useChatStore.ts
@@ -49,7 +49,199 @@ const randomId = () => {
   return Math.random().toString(36).slice(2);
 };
 
-const API_BASE = "";
+const KNOWN_APP_ROUTES = new Set(["chat", "ledger", "settings"]);
+
+let resolvedApiBase: string | null = null;
+let resolvingApiBase: Promise<string> | null = null;
+
+function normalizeBase(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return "";
+  }
+  if (/^(?:[a-z]+:)?\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function normalizePath(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return "";
+  }
+  if (/^(?:[a-z]+:)?\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function joinBaseAndPath(base: string, path: string): string {
+  if (!base) {
+    return path;
+  }
+  if (!path) {
+    return base;
+  }
+  if (/^(?:[a-z]+:)?\/\//i.test(path)) {
+    return path;
+  }
+  const sanitizedBase = base.replace(/\/+$/, "");
+  const sanitizedPath = path.replace(/^\/+/, "");
+  return `${sanitizedBase}/${sanitizedPath}`;
+}
+
+async function ensureApiBase(): Promise<string> {
+  if (resolvedApiBase !== null) {
+    return resolvedApiBase;
+  }
+  if (!resolvingApiBase) {
+    resolvingApiBase = resolveApiBase();
+  }
+  resolvedApiBase = await resolvingApiBase;
+  return resolvedApiBase;
+}
+
+function inferBaseFromLocation(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const trimmedPath = window.location.pathname.replace(/\/+$/, "");
+  if (!trimmedPath || trimmedPath === "/") {
+    return "";
+  }
+
+  const segments = trimmedPath.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return "";
+  }
+
+  const lastSegment = segments[segments.length - 1];
+  if (lastSegment.includes(".") || KNOWN_APP_ROUTES.has(lastSegment)) {
+    segments.pop();
+  }
+
+  if (segments.length === 0) {
+    return "";
+  }
+
+  return `/${segments.join("/")}`;
+}
+
+async function resolveApiBase(): Promise<string> {
+  const candidates = resolveApiBaseCandidates();
+  for (const base of candidates) {
+    try {
+      const response = await fetch(`${base}/status`, { method: "GET" });
+      if (response.ok) {
+        return base;
+      }
+    } catch (error) {
+      console.warn(`Kolibri API base candidate failed: ${base}`, error);
+    }
+  }
+  return candidates[candidates.length - 1] ?? "";
+}
+
+function resolveApiBaseCandidates(): string[] {
+  const candidates: string[] = [];
+
+  const addCandidate = (value: string) => {
+    if (!value || candidates.includes(value)) {
+      return;
+    }
+    candidates.push(value);
+  };
+
+  const rawBaseCandidates = resolveRawBaseCandidates();
+  const apiPathCandidates = resolveApiPathCandidates();
+
+  for (const rawBase of rawBaseCandidates) {
+    addCandidate(rawBase);
+    for (const apiPath of apiPathCandidates) {
+      addCandidate(joinBaseAndPath(rawBase, apiPath));
+    }
+  }
+
+  addCandidate("");
+
+  return candidates;
+}
+
+function resolveRawBaseCandidates(): string[] {
+  const rawBases: string[] = [];
+
+  const addBase = (value: string) => {
+    if (!value || rawBases.includes(value)) {
+      return;
+    }
+    rawBases.push(value);
+  };
+
+  addBase(normalizeBase(import.meta.env.VITE_API_BASE ?? ""));
+
+  if (typeof window !== "undefined") {
+    const globalWithApiBase = window as Window & {
+      __KOLIBRI_API_BASE__?: string;
+      __kolibriApiBase?: string;
+    };
+    addBase(
+      normalizeBase(
+        globalWithApiBase.__KOLIBRI_API_BASE__ ?? globalWithApiBase.__kolibriApiBase ?? ""
+      )
+    );
+
+    const meta = document
+      .querySelector('meta[name="kolibri-api-base"]')
+      ?.getAttribute("content");
+    addBase(normalizeBase(meta ?? ""));
+
+    addBase(normalizeBase(import.meta.env.BASE_URL ?? ""));
+    addBase(inferBaseFromLocation());
+  }
+
+  addBase("");
+
+  return rawBases;
+}
+
+function resolveApiPathCandidates(): string[] {
+  const apiPaths: string[] = [];
+
+  const addPath = (value: string) => {
+    if (apiPaths.includes(value)) {
+      return;
+    }
+    apiPaths.push(value);
+  };
+
+  addPath(normalizePath(import.meta.env.VITE_API_PREFIX ?? ""));
+
+  if (typeof window !== "undefined") {
+    const globalWithPrefix = window as Window & {
+      __KOLIBRI_API_PREFIX__?: string;
+      __kolibriApiPrefix?: string;
+    };
+    addPath(
+      normalizePath(
+        globalWithPrefix.__KOLIBRI_API_PREFIX__ ?? globalWithPrefix.__kolibriApiPrefix ?? ""
+      )
+    );
+
+    const meta = document
+      .querySelector('meta[name="kolibri-api-prefix"]')
+      ?.getAttribute("content");
+    addPath(normalizePath(meta ?? ""));
+  }
+
+  addPath("/api/v1");
+  addPath("/v1");
+  addPath("/api");
+  addPath("");
+
+  return apiPaths;
+}
 
 export const useChatStore = create<ChatState>()(
   persist(
@@ -72,92 +264,99 @@ export const useChatStore = create<ChatState>()(
         existingChatStream?.close();
         existingChainStream?.close();
 
-        const chatStream = new EventSource(
-          `${API_BASE}/api/v1/chat/stream?session_id=${sessionId}`
-        );
-        chatStream.onmessage = () => {};
-        let currentAssistantId: string | null = null;
-        chatStream.addEventListener("token", event => {
-          const data = JSON.parse((event as MessageEvent).data) as { content: string };
-          set(state => {
-            const messages = [...state.messages];
-            if (!currentAssistantId) {
-              currentAssistantId = randomId();
-              messages.push({
-                id: currentAssistantId,
-                role: "assistant",
-                content: "",
-                pending: true
+        void ensureApiBase()
+          .then(apiBase => {
+            const chatStream = new EventSource(
+              `${apiBase}/chat/stream?session_id=${sessionId}`
+            );
+            chatStream.onmessage = () => {};
+            let currentAssistantId: string | null = null;
+            chatStream.addEventListener("token", event => {
+              const data = JSON.parse((event as MessageEvent).data) as { content: string };
+              set(state => {
+                const messages = [...state.messages];
+                if (!currentAssistantId) {
+                  currentAssistantId = randomId();
+                  messages.push({
+                    id: currentAssistantId,
+                    role: "assistant",
+                    content: "",
+                    pending: true
+                  });
+                }
+                const idx = messages.findIndex(msg => msg.id === currentAssistantId);
+                if (idx >= 0) {
+                  messages[idx] = {
+                    ...messages[idx],
+                    content: `${messages[idx].content}${data.content}`
+                  };
+                }
+                return { messages };
               });
-            }
-            const idx = messages.findIndex(msg => msg.id === currentAssistantId);
-            if (idx >= 0) {
-              messages[idx] = {
-                ...messages[idx],
-                content: `${messages[idx].content}${data.content}`
-              };
-            }
-            return { messages };
-          });
-        });
-        chatStream.addEventListener("tool_call", event => {
-          const data = JSON.parse((event as MessageEvent).data);
-          set(state => ({
-            messages: [
-              ...state.messages,
-              {
-                id: randomId(),
-                role: "tool",
-                content: JSON.stringify(data, null, 2),
-                toolName: data.name
-              }
-            ]
-          }));
-        });
-        chatStream.addEventListener("final", event => {
-          const data = JSON.parse((event as MessageEvent).data) as { content: string };
-          set(state => {
-            const messages = [...state.messages];
-            if (currentAssistantId) {
-              const idx = messages.findIndex(msg => msg.id === currentAssistantId);
-              if (idx >= 0) {
-                messages[idx] = {
-                  ...messages[idx],
-                  content: data.content,
-                  pending: false,
-                  sources: extractSources(data.content)
-                };
-              }
-            } else {
-              messages.push({
-                id: randomId(),
-                role: "assistant",
-                content: data.content,
-                pending: false,
-                sources: extractSources(data.content)
+            });
+            chatStream.addEventListener("tool_call", event => {
+              const data = JSON.parse((event as MessageEvent).data);
+              set(state => ({
+                messages: [
+                  ...state.messages,
+                  {
+                    id: randomId(),
+                    role: "tool",
+                    content: JSON.stringify(data, null, 2),
+                    toolName: data.name
+                  }
+                ]
+              }));
+            });
+            chatStream.addEventListener("final", event => {
+              const data = JSON.parse((event as MessageEvent).data) as { content: string };
+              set(state => {
+                const messages = [...state.messages];
+                if (currentAssistantId) {
+                  const idx = messages.findIndex(msg => msg.id === currentAssistantId);
+                  if (idx >= 0) {
+                    messages[idx] = {
+                      ...messages[idx],
+                      content: data.content,
+                      pending: false,
+                      sources: extractSources(data.content)
+                    };
+                  }
+                } else {
+                  messages.push({
+                    id: randomId(),
+                    role: "assistant",
+                    content: data.content,
+                    pending: false,
+                    sources: extractSources(data.content)
+                  });
+                }
+                currentAssistantId = null;
+                return { messages };
               });
-            }
-            currentAssistantId = null;
-            return { messages };
+            });
+
+            const chainStream = new EventSource(`${apiBase}/chain/stream`);
+            chainStream.addEventListener("block", event => {
+              const data = JSON.parse((event as MessageEvent).data);
+              set(state => ({
+                chain: [
+                  {
+                    id: data.id,
+                    timestamp: data.timestamp,
+                    payload: data.payload
+                  },
+                  ...state.chain
+                ].slice(0, 50)
+              }));
+            });
+
+            set({ connected: true, chatStream, chainStream });
+          })
+          .catch(error => {
+            console.error("Kolibri chat stream connection failed", error);
+            set({ connected: false, chatStream: null, chainStream: null });
           });
-        });
-
-        const chainStream = new EventSource(`${API_BASE}/api/v1/chain/stream`);
-        chainStream.addEventListener("block", event => {
-          const data = JSON.parse((event as MessageEvent).data);
-          set(state => ({
-            chain: [
-              {
-                id: data.id,
-                timestamp: data.timestamp,
-                payload: data.payload
-              },
-              ...state.chain
-            ].slice(0, 50)
-          }));
-        });
-
-        set({ connected: true, chatStream, chainStream });
       },
       sendMessage: async content => {
         const { sessionId } = get();
@@ -169,7 +368,8 @@ export const useChatStore = create<ChatState>()(
         };
         set(state => ({ messages: [...state.messages, message] }));
         try {
-          await fetch(`${API_BASE}/api/v1/chat`, {
+          const apiBase = await ensureApiBase();
+          await fetch(`${apiBase}/chat`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ session_id: sessionId, message: content })
@@ -180,6 +380,7 @@ export const useChatStore = create<ChatState>()(
               msg.id === message.id ? { ...msg, pending: true } : msg
             )
           }));
+          console.error("Kolibri chat request failed", error);
         }
       },
       setView: view => set({ activeView: view }),


### PR DESCRIPTION
## Summary
- extend API base resolution to mix configured roots with detected prefixes and probe `/status` so deployments with `/api/v1`, `/v1`, or custom paths work
- update chat streaming and message calls to target the resolved API root instead of hard-coded `/api/v1` routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff435d7208323b7481dad4a545681