### PR TITLE
Polish smart client math tooling UI

### DIFF
--- a/smart_client/backend/app/chat.py
+++ b/smart_client/backend/app/chat.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, List
+import re
+from typing import Any, Dict, List, Optional
 
 from .audit import audit_logger
 from .memory import ChatSession, SessionManager
@@ -17,6 +18,7 @@ class ChatOrchestrator:
         session.add_message("user", message)
         await session.publish("token", {"content": ""})  # trigger client to start display
         sources: List[Dict[str, Any]] = []
+        math_result: Optional[Dict[str, Any]] = None
 
         if "миссия" in message.lower():
             plan = execute_tool(
@@ -33,17 +35,49 @@ class ChatOrchestrator:
                 {"name": "kg_search", "payload": {"query": message, "hits": sources}},
             )
 
+        if self._looks_like_math(message):
+            try:
+                math_result = execute_tool("math_solver", {"problem": message})
+            except Exception as exc:  # noqa: BLE001
+                math_result = {
+                    "type": "error",
+                    "summary": "Не удалось решить задачу.",
+                    "answer": str(exc),
+                    "steps": [],
+                    "references": [],
+                }
+                await session.publish(
+                    "tool_call",
+                    {
+                        "name": "math_solver",
+                        "payload": {"error": str(exc)},
+                    },
+                )
+            else:
+                await session.publish(
+                    "tool_call",
+                    {
+                        "name": "math_solver",
+                        "payload": math_result,
+                    },
+                )
+                for reference in math_result.get("references", []):
+                    sources.append({"text": reference, "source": "math_solver", "score": 1.0})
+
         run_block = execute_tool("kolibri_run", {"steps": 3, "seed": len(message)})
         await session.publish(
             "tool_call",
             {"name": "kolibri_run", "payload": run_block["block"]},
         )
 
-        short_answer = self._compose_short_answer(message, sources)
-        explanation = self._compose_explanation(sources)
-        next_steps = self._compose_next_steps(sources)
+        short_answer = self._compose_short_answer(message, sources, math_result)
+        explanation = self._compose_explanation(sources, math_result)
+        next_steps = self._compose_next_steps(sources, math_result)
+        math_section = self._format_math_result(math_result)
 
         full_response = f"{short_answer}\n\nКак это узнали: {explanation}\n\nЧто дальше: {next_steps}"
+        if math_section:
+            full_response += f"\n\nМатематика: {math_section}"
         if sources:
             full_response += "\n\nИсточники:" + "".join(
                 f"\n• {item['source']}"
@@ -52,7 +86,7 @@ class ChatOrchestrator:
         else:
             full_response += "\n\nКак проверили: внутренний запуск kolibri_run показал стабильный результат."
 
-        session.add_message("assistant", full_response, sources=sources)
+        session.add_message("assistant", full_response, sources=sources, math=math_result)
         await self._stream_text(session, full_response)
         audit_logger.log(
             "assistant",
@@ -67,24 +101,78 @@ class ChatOrchestrator:
             await asyncio.sleep(0.05)
         await session.publish("final", {"content": text})
 
-    def _compose_short_answer(self, message: str, sources: List[Dict[str, Any]]) -> str:
+    def _compose_short_answer(
+        self,
+        message: str,
+        sources: List[Dict[str, Any]],
+        math_result: Optional[Dict[str, Any]],
+    ) -> str:
         if "не знаю" in message.lower():
             return "Пока данных маловато, но я могу поискать больше сведений."
+        if math_result and math_result.get("answer"):
+            return f"Решение найдено: {math_result['answer']}"
         if sources:
             return "Главная мысль: сведения подтверждаются локальным графом знаний."
         return "Я сохранил запрос и готов уточнить детали."
 
-    def _compose_explanation(self, sources: List[Dict[str, Any]]) -> str:
+    def _compose_explanation(
+        self,
+        sources: List[Dict[str, Any]],
+        math_result: Optional[Dict[str, Any]],
+    ) -> str:
+        if math_result and math_result.get("summary"):
+            return math_result["summary"]
         if sources:
             top = sources[0]
             return f"опирался на запись из {top['source']} и свежий kolibri_run"
         return "использовал внутреннюю проверку kolibri_run без внешних источников"
 
-    def _compose_next_steps(self, sources: List[Dict[str, Any]]) -> str:
+    def _compose_next_steps(
+        self,
+        sources: List[Dict[str, Any]],
+        math_result: Optional[Dict[str, Any]],
+    ) -> str:
         steps = ["уточнить критерии успеха", "обновить миссию в Ledger"]
         if sources:
             steps.insert(0, "изучить отмеченные источники")
+        if math_result and math_result.get("type") == "equation":
+            steps.insert(0, "подставить решение в исходное уравнение для проверки")
         return ", ".join(steps)
+
+    def _format_math_result(self, math_result: Optional[Dict[str, Any]]) -> str:
+        if not math_result:
+            return ""
+        if math_result.get("type") == "error":
+            return math_result.get("summary", "")
+        parts = [math_result.get("summary", "")]
+        answer = math_result.get("answer")
+        if answer:
+            parts.append(f"Итог: {answer}")
+        steps = math_result.get("steps") or []
+        if steps:
+            steps_lines = "\n".join(f"• {step}" for step in steps)
+            parts.append(f"Шаги:\n{steps_lines}")
+        return "\n".join(filter(None, parts))
+
+    def _looks_like_math(self, message: str) -> bool:
+        lowered = message.lower()
+        math_keywords = [
+            "реши",
+            "уравнение",
+            "площадь",
+            "периметр",
+            "радиус",
+            "диаметр",
+            "длина",
+            "формула",
+            "sin",
+            "cos",
+            "tan",
+            "sqrt",
+        ]
+        if any(keyword in lowered for keyword in math_keywords):
+            return True
+        return bool(re.search(r"[0-9].*[=+\-*/^]", message))
 
 
 __all__ = ["ChatOrchestrator"]

--- a/smart_client/backend/app/kprl.py
+++ b/smart_client/backend/app/kprl.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from .config import settings
 

--- a/smart_client/backend/app/tools.py
+++ b/smart_client/backend/app/tools.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import math
 import random
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
+
+import sympy as sp
+from sympy.core.sympify import SympifyError
 
 from .audit import audit_logger
 from .kprl import kprl_manager
@@ -127,12 +132,166 @@ def iot_safe_action(device_id: str, action: str, confirm: bool = False) -> Dict[
     }
 
 
+def _parse_number(value: str) -> float:
+    return float(value.replace(",", "."))
+
+
+def _geometry_solver(problem: str) -> Dict[str, Any] | None:
+    lower = problem.lower()
+    number_pattern = r"[-+]?\d+(?:[\.,]\d+)?"
+
+    if "круг" in lower or "circle" in lower:
+        radius_match = re.search(r"(?:радиус(?:ом)?|radius)\s*(?P<radius>" + number_pattern + ")", lower)
+        if radius_match:
+            radius = _parse_number(radius_match.group("radius"))
+            area = math.pi * radius**2
+            circumference = 2 * math.pi * radius
+            return {
+                "type": "geometry",
+                "figure": "circle",
+                "summary": (
+                    f"Для круга радиусом {radius:.6g} площадь {area:.6g}, длина окружности {circumference:.6g}."
+                ),
+                "answer": f"S = πr² = {area:.6g}, L = 2πr = {circumference:.6g}",
+                "steps": [
+                    "Используем формулу площади круга S = πr².",
+                    "Используем формулу длины окружности L = 2πr.",
+                ],
+                "references": ["Геометрия: площадь и длина окружности"],
+            }
+
+    if "прямоугольник" in lower or "rectangle" in lower:
+        length_match = re.search(r"(?:длина|length)\s*(?P<length>" + number_pattern + ")", lower)
+        width_match = re.search(r"(?:ширина|width)\s*(?P<width>" + number_pattern + ")", lower)
+        if length_match and width_match:
+            length = _parse_number(length_match.group("length"))
+            width = _parse_number(width_match.group("width"))
+            area = length * width
+            perimeter = 2 * (length + width)
+            return {
+                "type": "geometry",
+                "figure": "rectangle",
+                "summary": (
+                    f"Площадь прямоугольника {area:.6g}, периметр {perimeter:.6g}."
+                ),
+                "answer": f"S = a·b = {area:.6g}, P = 2(a+b) = {perimeter:.6g}",
+                "steps": [
+                    "Используем формулу площади прямоугольника S = a·b.",
+                    "Используем формулу периметра P = 2(a + b).",
+                ],
+                "references": ["Геометрия: площадь и периметр прямоугольника"],
+            }
+
+    if "треугольник" in lower or "triangle" in lower:
+        base_match = re.search(r"(?:основани[ея]|base)\s*(?P<base>" + number_pattern + ")", lower)
+        height_match = re.search(r"(?:высот[аеы]|height)\s*(?P<height>" + number_pattern + ")", lower)
+        if base_match and height_match:
+            base = _parse_number(base_match.group("base"))
+            height = _parse_number(height_match.group("height"))
+            area = 0.5 * base * height
+            return {
+                "type": "geometry",
+                "figure": "triangle",
+                "summary": f"Площадь треугольника {area:.6g}.",
+                "answer": f"S = 1/2 · a · h = {area:.6g}",
+                "steps": [
+                    "Используем формулу площади треугольника S = 1/2 · a · h.",
+                ],
+                "references": ["Геометрия: площадь треугольника"],
+            }
+
+    return None
+
+
+def math_solver(problem: str) -> Dict[str, Any]:
+    geometry = _geometry_solver(problem)
+    if geometry:
+        audit_logger.log("assistant", "math_solver", {"problem": problem, "type": geometry["figure"]})
+        return geometry
+
+    allowed_chars = set("0123456789+-*/^=()., πabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    cleaned = "".join(ch for ch in problem if ch in allowed_chars or ch.isspace())
+    cleaned = cleaned.replace(",", ".").replace("π", "pi")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+    expression_text = cleaned or problem
+
+    locals_map: Dict[str, sp.Symbol] = {}
+    for symbol in sorted(set(re.findall(r"[a-zA-Z]", expression_text))):
+        locals_map[symbol] = sp.symbols(symbol)
+    if not locals_map:
+        locals_map["x"] = sp.symbols("x")
+
+    try:
+        if "=" in expression_text:
+            left, right = expression_text.split("=", 1)
+            left_expr = sp.sympify(left, locals=locals_map)
+            right_expr = sp.sympify(right, locals=locals_map)
+            equation = sp.Eq(left_expr, right_expr)
+            solutions = sp.solve(equation, list(locals_map.values()), dict=True)
+            if solutions:
+                formatted = [
+                    ", ".join(f"{str(var)} = {sp.simplify(value)}" for var, value in solution.items())
+                    for solution in solutions
+                ]
+                answer = "; ".join(formatted)
+            else:
+                answer = "Решений не найдено в вещественных числах."
+            result = {
+                "type": "equation",
+                "summary": f"Решил уравнение {sp.pretty(equation)}.",
+                "answer": answer,
+                "steps": [
+                    f"Записываем уравнение: {sp.pretty(equation)}.",
+                    "Решаем уравнение с помощью символьного решателя SymPy.",
+                ],
+                "references": ["Алгебра: решение уравнений", "SymPy solve"],
+            }
+        else:
+            expr = sp.sympify(expression_text, locals=locals_map)
+            exact_value = sp.simplify(expr)
+            try:
+                numeric_value = float(exact_value.evalf())
+            except (TypeError, ValueError):
+                numeric_value = None
+            steps = [f"Упрощаем выражение: {sp.pretty(expr)} → {exact_value}."]
+            if numeric_value is not None:
+                steps.append(f"Численное значение: {numeric_value:.6g}.")
+            result = {
+                "type": "expression",
+                "summary": "Вычислено алгебраическое выражение.",
+                "answer": (
+                    f"точно: {exact_value}" + (f", приближенно: {numeric_value:.6g}" if numeric_value is not None else "")
+                ),
+                "steps": steps,
+                "references": ["Алгебра: преобразование выражений", "SymPy simplify"],
+            }
+    except SympifyError as exc:
+        audit_logger.log(
+            "assistant",
+            "math_solver_error",
+            {"problem": problem, "error": str(exc)},
+        )
+        return {
+            "type": "error",
+            "summary": "Не удалось разобрать математическое выражение.",
+            "answer": "",
+            "steps": [],
+            "references": [],
+            "error": str(exc),
+        }
+
+    audit_logger.log("assistant", "math_solver", {"problem": problem, "type": result["type"]})
+    return result
+
+
 TOOL_HANDLERS = {
     "kg_search": kg_search,
     "kolibri_run": kolibri_run,
     "kolibri_verify": kolibri_verify,
     "mission_plan": mission_plan,
     "iot_safe_action": iot_safe_action,
+    "math_solver": math_solver,
 }
 
 

--- a/smart_client/backend/pyproject.toml
+++ b/smart_client/backend/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
     "uvicorn>=0.27.0",
     "pydantic>=2.6.1",
     "sse-starlette>=1.8.2",
-    "aiofiles>=23.1.0"
+    "aiofiles>=23.1.0",
+    "httpx>=0.26.0",
+    "sympy>=1.12"
 ]
 
 [project.optional-dependencies]

--- a/smart_client/backend/tests/test_math_solver.py
+++ b/smart_client/backend/tests/test_math_solver.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from app.tools import execute_tool
+
+
+def test_math_solver_equation_solves_linear():
+    result = execute_tool("math_solver", {"problem": "2*x + 4 = 10"})
+    assert result["type"] == "equation"
+    assert "x = 3" in result["answer"]
+    assert any("SymPy" in reference for reference in result["references"])
+
+
+def test_math_solver_circle_area():
+    result = execute_tool("math_solver", {"problem": "Площадь круга радиусом 5"})
+    assert result["type"] == "geometry"
+    assert result["figure"] == "circle"
+    assert "πr²" in result["answer"]

--- a/smart_client/backend/tests/test_smart_client_e2e.py
+++ b/smart_client/backend/tests/test_smart_client_e2e.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -40,3 +41,34 @@ def test_chat_tool_chain_flow():
         json={"payload": {"device_id": "lamp-1", "action": "on"}},
     ).json()
     assert tool["result"]["allowed"] is False
+
+
+@pytest.mark.parametrize(
+    "problem, expected",
+    [
+        ("Реши уравнение 2*x + 4 = 10", "x = 3"),
+        ("Площадь круга радиусом 3", "S = πr²"),
+    ],
+)
+def test_chat_math_solver(problem: str, expected: str):
+    client = TestClient(app)
+    session_id = f"math-{abs(hash(problem))}"
+
+    response = client.post(
+        "/api/v1/chat",
+        json={"session_id": session_id, "message": problem},
+    )
+    assert response.status_code == 200
+
+    assistant_message = None
+    for _ in range(40):
+        history = client.get("/api/v1/history", params={"session_id": session_id}).json()
+        assistants = [m for m in history["messages"] if m["role"] == "assistant"]
+        if assistants:
+            assistant_message = assistants[-1]
+            if expected in assistant_message["content"]:
+                break
+        time.sleep(0.2)
+
+    assert assistant_message, "не дождались ответа ассистента"
+    assert expected in assistant_message["content"]

--- a/smart_client/frontend/src/components/ToolBadge.tsx
+++ b/smart_client/frontend/src/components/ToolBadge.tsx
@@ -5,14 +5,106 @@ interface Props {
   message: ChatMessage;
 }
 
+type MathPayload = {
+  type?: string;
+  summary?: string;
+  answer?: unknown;
+  steps?: unknown;
+  references?: unknown;
+  error?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function renderMathPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const math = payload as MathPayload;
+  const isError = math.type === "error" || typeof math.error === "string";
+  const summary = typeof math.summary === "string" ? math.summary : undefined;
+  const answerValue = math.answer;
+  const stepsValue = math.steps;
+  const referencesValue = math.references;
+
+  const answer =
+    typeof answerValue === "string"
+      ? answerValue
+      : answerValue !== undefined
+      ? JSON.stringify(answerValue, null, 2)
+      : undefined;
+
+  const steps = Array.isArray(stepsValue)
+    ? stepsValue.map(step => (typeof step === "string" ? step : JSON.stringify(step)))
+    : [];
+
+  const references = Array.isArray(referencesValue)
+    ? referencesValue.map(ref => (typeof ref === "string" ? ref : JSON.stringify(ref)))
+    : [];
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs uppercase tracking-wide text-amber-200/80">Математический решатель</div>
+      {isError ? (
+        <p className="text-sm text-amber-100/80">
+          {math.error ?? summary ?? "Не удалось вычислить результат."}
+        </p>
+      ) : (
+        <div className="space-y-2 text-sm text-amber-50">
+          {summary && <p className="font-semibold text-amber-100">{summary}</p>}
+          {answer && (
+            <div>
+              <div className="text-xs uppercase tracking-wide text-amber-200/70">Итог</div>
+              <pre className="mt-1 whitespace-pre-wrap text-sm leading-snug text-amber-50">{answer}</pre>
+            </div>
+          )}
+          {steps.length > 0 && (
+            <div>
+              <div className="text-xs uppercase tracking-wide text-amber-200/70">Шаги</div>
+              <ul className="mt-1 list-disc space-y-1 pl-5">
+                {steps.map((step, index) => (
+                  <li key={`${step}-${index}`} className="text-amber-100/90">
+                    {step}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {references.length > 0 && (
+            <div>
+              <div className="text-xs uppercase tracking-wide text-amber-200/70">Ссылки</div>
+              <ul className="mt-1 list-disc space-y-1 pl-5">
+                {references.map(ref => (
+                  <li key={ref} className="text-amber-100/80">
+                    {ref}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function ToolBadge({ message }: Props) {
   if (message.role !== "tool") return null;
+
+  const payload = renderMathPayload(message.toolPayload);
+
   return (
     <Card className="bg-amber-500/10 text-xs text-amber-200">
       <p className="font-semibold">Вызов инструмента: {message.toolName ?? "?"}</p>
-      <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap text-[11px] leading-snug text-amber-100">
-        {message.content}
-      </pre>
+      <div className="mt-2 max-h-48 overflow-auto text-[12px] leading-snug">
+        {payload ? (
+          payload
+        ) : (
+          <pre className="whitespace-pre-wrap text-amber-100">{message.content}</pre>
+        )}
+      </div>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- clean up the chat store API-base discovery, SSE handling, and tool payload parsing so the frontend can reliably connect to the upgraded backend
- render math solver tool calls with structured summaries, answers, steps, and references instead of raw JSON dumps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03dc45050832396817b0c1c9f6409