### PR TITLE
Fix chat store API base resolution and SSE handling

### DIFF
--- a/smart_client/frontend/src/state/useChatStore.ts
+++ b/smart_client/frontend/src/state/useChatStore.ts
@@ -62,20 +62,25 @@ function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
-
 function normalizeCandidate(value: string | null | undefined): string {
   if (!value) {
     return "";
   }
   const trimmed = value.trim();
-
-const KNOWN_APP_ROUTES = new Set(["chat", "ledger", "settings"]);
-
-let resolvedApiBase: string | null = null;
-let resolvingApiBase: Promise<string> | null = null;
+  if (!trimmed) {
+    return "";
+  }
+  if (/^(?:[a-z]+:)?\/\//i.test(trimmed)) {
+    return trimTrailingSlash(trimmed);
+  }
+  if (trimmed.startsWith("/")) {
+    return trimTrailingSlash(trimmed);
+  }
+  return `/${trimTrailingSlash(trimmed)}`;
+}
 
 function normalizeBase(value: string): string {
-  const trimmed = value.trim().replace(/\/+$/, "");
+  const trimmed = trimTrailingSlash(value.trim());
   if (!trimmed) {
     return "";
   }
@@ -86,35 +91,9 @@ function normalizeBase(value: string): string {
 }
 
 function normalizePath(value: string): string {
-  const trimmed = value.trim().replace(/\/+$/, "");
-
-function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
-}
-
-function normalizeCandidate(value: string | null | undefined): string {
-  if (!value) {
-    return "";
-  }
-  const trimmed = value.trim();
-
-
+  const trimmed = trimTrailingSlash(value.trim());
   if (!trimmed) {
     return "";
-  }
-  if (/^(?:[a-z]+:)?\/\//i.test(trimmed)) {
-
-    return trimTrailingSlash(trimmed);
-  }
-  if (trimmed.startsWith("/")) {
-    return trimTrailingSlash(trimmed);
-  }
-  return `/${trimTrailingSlash(trimmed)}`;
-}
-
-
-
-    return trimmed;
   }
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
@@ -143,14 +122,6 @@ async function ensureApiBase(): Promise<string> {
   }
   resolvedApiBase = await resolvingApiBase;
   return resolvedApiBase;
-
-    return trimTrailingSlash(trimmed);
-  }
-  if (trimmed.startsWith("/")) {
-    return trimTrailingSlash(trimmed);
-  }
-  return `/${trimTrailingSlash(trimmed)}`;
-
 }
 
 function inferBaseFromLocation(): string {
@@ -163,20 +134,6 @@ function inferBaseFromLocation(): string {
     return "";
   }
 
-
-
-  const trimmedPath = window.location.pathname.replace(/\/+$/, "");
-  if (!trimmedPath || trimmedPath === "/") {
-    return "";
-  }
-
-
-  const trimmedPath = trimTrailingSlash(window.location.pathname);
-  if (!trimmedPath || trimmedPath === "/") {
-    return "";
-  }
-
-
   const segments = trimmedPath.split("/").filter(Boolean);
   if (segments.length === 0) {
     return "";
@@ -185,13 +142,10 @@ function inferBaseFromLocation(): string {
   if (lastSegment.includes(".") || KNOWN_APP_ROUTES.has(lastSegment)) {
     segments.pop();
   }
-
-
   if (segments.length === 0) {
     return "";
   }
   return `/${segments.join("/")}`;
-
 }
 
 async function resolveApiBase(): Promise<string> {
@@ -207,7 +161,6 @@ async function resolveApiBase(): Promise<string> {
     }
   }
   return candidates[candidates.length - 1] ?? "";
-
 }
 
 function resolveApiBaseCandidates(): string[] {
@@ -252,58 +205,23 @@ function resolveRawBaseCandidates(): string[] {
 
   addBase(normalizeBase(import.meta.env.VITE_API_BASE ?? ""));
 
-  if (segments.length === 0) {
-    return "";
-  }
-  return `/${segments.join("/")}`;
-}
-
-function resolveApiBaseCandidates(): string[] {
-  const candidates: string[] = [];
-  const addCandidate = (value: string) => {
-    const normalized = normalizeCandidate(value);
-    if (normalized === "" && candidates.includes("")) {
-      return;
-    }
-    if (normalized && candidates.includes(normalized)) {
-      return;
-    }
-    candidates.push(normalized);
-  };
-
-  addCandidate(import.meta.env.VITE_API_BASE ?? "");
-
-
-
   if (typeof window !== "undefined") {
     const globalWithApiBase = window as Window & {
       __KOLIBRI_API_BASE__?: string;
       __kolibriApiBase?: string;
     };
 
-    addCandidate(globalWithApiBase.__KOLIBRI_API_BASE__ ?? globalWithApiBase.__kolibriApiBase ?? "");
-
-
     addBase(
       normalizeBase(
-        globalWithApiBase.__KOLIBRI_API_BASE__ ?? globalWithApiBase.__kolibriApiBase ?? ""
-      )
+        globalWithApiBase.__KOLIBRI_API_BASE__ ?? globalWithApiBase.__kolibriApiBase ?? "",
+      ),
     );
-
-
-    addCandidate(globalWithApiBase.__KOLIBRI_API_BASE__ ?? globalWithApiBase.__kolibriApiBase ?? "");
-
 
     const meta = document
       .querySelector('meta[name="kolibri-api-base"]')
       ?.getAttribute("content");
 
-    addCandidate(meta ?? "");
-
-
-
     addBase(normalizeBase(meta ?? ""));
-
     addBase(normalizeBase(import.meta.env.BASE_URL ?? ""));
     addBase(inferBaseFromLocation());
   }
@@ -332,8 +250,8 @@ function resolveApiPathCandidates(): string[] {
     };
     addPath(
       normalizePath(
-        globalWithPrefix.__KOLIBRI_API_PREFIX__ ?? globalWithPrefix.__kolibriApiPrefix ?? ""
-      )
+        globalWithPrefix.__KOLIBRI_API_PREFIX__ ?? globalWithPrefix.__kolibriApiPrefix ?? "",
+      ),
     );
 
     const meta = document
@@ -348,45 +266,6 @@ function resolveApiPathCandidates(): string[] {
   addPath("");
 
   return apiPaths;
-
-    addCandidate(meta ?? "");
-
-
-    addCandidate(import.meta.env.BASE_URL ?? "");
-    addCandidate(inferBaseFromLocation());
-  }
-
-  addCandidate("");
-
-  return candidates;
-}
-
-async function detectApiBase(): Promise<string> {
-  const candidates = resolveApiBaseCandidates();
-  for (const base of candidates) {
-    try {
-      const response = await fetch(`${base}/api/v1/status`, { method: "GET" });
-      if (response.ok) {
-        return base;
-      }
-    } catch (error) {
-      console.warn(`Kolibri API base candidate failed: ${base}`, error);
-    }
-  }
-  return candidates[candidates.length - 1] ?? "";
-}
-
-async function ensureApiBase(): Promise<string> {
-  if (resolvedApiBase !== null) {
-    return resolvedApiBase;
-  }
-  if (!resolvingApiBase) {
-    resolvingApiBase = detectApiBase().then(base => {
-      resolvedApiBase = base;
-      return base;
-    });
-  }
-  return resolvingApiBase;
 }
 
 function extractSources(content: string): SourceItem[] | undefined {
@@ -397,7 +276,6 @@ function extractSources(content: string): SourceItem[] | undefined {
   return tail.split("\n").map(line => ({ source: line.replace(/^•\s*/, "").trim() }));
 }
 
-
 function selectToolPayload(data: Record<string, unknown>): unknown {
   if ("payload" in data) {
     return data.payload;
@@ -405,15 +283,8 @@ function selectToolPayload(data: Record<string, unknown>): unknown {
   if ("result" in data) {
     return data.result;
   }
-  return data;
-
-
-function selectToolPayload(data: Record<string, unknown>): unknown {
-  if ("payload" in data) {
-    return data.payload;
-  }
-  if ("result" in data) {
-    return data.result;
+  if ("parameters" in data) {
+    return data.parameters;
   }
   return data;
 }
@@ -438,29 +309,24 @@ export const useChatStore = create<ChatState>()(
           chatStream: existingChatStream,
           chainStream: existingChainStream,
         } = get();
-        if (connected && existingChatStream && existingChatStream.readyState !== EventSource.CLOSED) {
+
+        if (
+          connected &&
+          existingChatStream &&
+          existingChatStream.readyState !== EventSource.CLOSED
+        ) {
           return;
         }
+
         existingChatStream?.close();
         existingChainStream?.close();
 
         void ensureApiBase()
           .then(apiBase => {
             const chatStream = new EventSource(
-
-              `${apiBase}/api/v1/chat/stream?session_id=${sessionId}`,
-
-
-              `${apiBase}/chat/stream?session_id=${sessionId}`
-
+              `${apiBase}/chat/stream?session_id=${sessionId}`,
             );
             let currentAssistantId: string | null = null;
-
-
-              `${apiBase}/api/v1/chat/stream?session_id=${sessionId}`,
-            );
-            let currentAssistantId: string | null = null;
-
 
             chatStream.onopen = () => {
               set({ connected: true });
@@ -472,7 +338,6 @@ export const useChatStore = create<ChatState>()(
               set({ connected: false, chatStream: null, chainStream: null });
             };
 
-
             chatStream.addEventListener("token", event => {
               const data = JSON.parse((event as MessageEvent).data) as { content: string };
               set(state => {
@@ -483,101 +348,58 @@ export const useChatStore = create<ChatState>()(
                     id: currentAssistantId,
                     role: "assistant",
                     content: "",
-
                     pending: true,
-
-
-                    pending: true
-
-                    pending: true,
-
                   });
                 }
-                const idx = messages.findIndex(msg => msg.id === currentAssistantId);
-                if (idx >= 0) {
-                  messages[idx] = {
-                    ...messages[idx],
 
-                    content: `${messages[idx].content}${data.content}`,
-
-
-                    content: `${messages[idx].content}${data.content}`
-
-                    content: `${messages[idx].content}${data.content}`,
-
-
+                const index = messages.findIndex(message => message.id === currentAssistantId);
+                if (index >= 0) {
+                  const current = messages[index];
+                  messages[index] = {
+                    ...current,
+                    content: `${current.content}${data.content}`,
                   };
                 }
+
                 return { messages };
               });
             });
 
             chatStream.addEventListener("tool_call", event => {
-
-              const data = JSON.parse((event as MessageEvent).data);
-
-
-            chatStream.addEventListener("tool_call", event => {
-
               const raw = JSON.parse((event as MessageEvent).data) as Record<string, unknown> & {
                 name?: string;
               };
               const payload = selectToolPayload(raw);
-
               set(state => ({
                 messages: [
                   ...state.messages,
                   {
                     id: randomId(),
                     role: "tool",
-
-                    content: typeof payload === "string" ? payload : JSON.stringify(payload, null, 2),
+                    content:
+                      typeof payload === "string"
+                        ? payload
+                        : JSON.stringify(payload, null, 2),
+                    pending: false,
                     toolName: typeof raw.name === "string" ? raw.name : undefined,
                     toolPayload: payload,
                   },
                 ],
               }));
             });
-
-
-
-                    content: JSON.stringify(data, null, 2),
-                    toolName: data.name
-                  }
-                ]
-              }));
-            });
-
-                    content: typeof payload === "string" ? payload : JSON.stringify(payload, null, 2),
-                    toolName: typeof raw.name === "string" ? raw.name : undefined,
-                    toolPayload: payload,
-                  },
-                ],
-              }));
-            });
-
-
 
             chatStream.addEventListener("final", event => {
               const data = JSON.parse((event as MessageEvent).data) as { content: string };
               set(state => {
                 const messages = [...state.messages];
                 if (currentAssistantId) {
-                  const idx = messages.findIndex(msg => msg.id === currentAssistantId);
-                  if (idx >= 0) {
-                    messages[idx] = {
-                      ...messages[idx],
+                  const index = messages.findIndex(message => message.id === currentAssistantId);
+                  if (index >= 0) {
+                    messages[index] = {
+                      ...messages[index],
                       content: data.content,
                       pending: false,
-
                       sources: extractSources(data.content),
-
-
-                      sources: extractSources(data.content)
-
-                      sources: extractSources(data.content),
-
-
                     };
                   }
                 } else {
@@ -586,15 +408,7 @@ export const useChatStore = create<ChatState>()(
                     role: "assistant",
                     content: data.content,
                     pending: false,
-
                     sources: extractSources(data.content),
-
-
-                    sources: extractSources(data.content)
-
-                    sources: extractSources(data.content),
-
-
                   });
                 }
                 currentAssistantId = null;
@@ -604,37 +418,19 @@ export const useChatStore = create<ChatState>()(
 
             const chainStream = new EventSource(`${apiBase}/chain/stream`);
 
-            const chainStream = new EventSource(`${apiBase}/api/v1/chain/stream`);
-
             chainStream.addEventListener("block", event => {
-              const data = JSON.parse((event as MessageEvent).data);
+              const data = JSON.parse((event as MessageEvent).data) as ChainBlock;
               set(state => ({
                 chain: [
                   {
                     id: data.id,
                     timestamp: data.timestamp,
-
-                    payload: data.payload,
-
-
-                    payload: data.payload
-
-                  },
-                  ...state.chain,
-                ].slice(0, 50),
-              }));
-            });
-
-
-            set({ connected: true, chatStream, chainStream });
-
                     payload: data.payload,
                   },
                   ...state.chain,
                 ].slice(0, 50),
               }));
             });
-
 
             chainStream.onerror = event => {
               console.error("Kolibri chain stream error", event);
@@ -642,7 +438,6 @@ export const useChatStore = create<ChatState>()(
             };
 
             set({ chatStream, chainStream });
-
           })
           .catch(error => {
             console.error("Kolibri chat stream connection failed", error);
@@ -660,11 +455,7 @@ export const useChatStore = create<ChatState>()(
         set(state => ({ messages: [...state.messages, message] }));
         try {
           const apiBase = await ensureApiBase();
-
           await fetch(`${apiBase}/chat`, {
-
-          await fetch(`${apiBase}/api/v1/chat`, {
-
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ session_id: sessionId, message: content }),


### PR DESCRIPTION
## Summary
- rebuild the chat store API base discovery helpers to normalize candidates and cache the selected endpoint
- streamline the chat store SSE connection logic, ensuring tool payloads and final messages are handled cleanly without duplicate paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d05c5b2dcc83239ffba94d42cc5513