### PR TITLE
Implement WASM exports and improve build script

### DIFF
--- a/wasm/build_wasm.sh
+++ b/wasm/build_wasm.sh
@@ -3,18 +3,26 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_WASM="$ROOT_DIR/ui/kolibri.wasm"
 
-CORE_FILES=$(find "$ROOT_DIR/core" -name '*.c' ! -name 'main.c')
-
 mapfile -t CORE_FILES < <(find "$ROOT_DIR/core" -name '*.c' ! -name 'main.c')
+
+if [[ ${#CORE_FILES[@]} -eq 0 ]]; then
+  echo "no core sources found" >&2
+  exit 1
+fi
+
+if ! command -v clang >/dev/null 2>&1; then
+  echo "clang (with wasm32-wasi target) is required" >&2
+  exit 1
+fi
 
 clang --target=wasm32-wasi \
   -O2 \
   -nostartfiles \
-  -Wl,--export-all \
   -Wl,--no-entry \
+  -Wl,--export=memory \
+  -Wl,--strip-debug \
   -o "$OUT_WASM" \
-
-  wasm/export.c $CORE_FILES
-
   wasm/export.c "${CORE_FILES[@]}"
+
+echo "built $OUT_WASM"
 

--- a/wasm/export.c
+++ b/wasm/export.c
@@ -1,3 +1,60 @@
 #include "export.h"
 
+#include <stdint.h>
+#include <stddef.h>
+
 #include "../core/kolibri.h"
+
+static char *wasm_ptr(uint32_t offset) {
+    return (char *)(uintptr_t)offset;
+}
+
+static const char *wasm_cptr(uint32_t offset) {
+    return (const char *)(uintptr_t)offset;
+}
+
+__attribute__((export_name("kol_init")))
+int wasm_kol_init(uint32_t depth, uint32_t seed) {
+    return kol_init((uint8_t)depth, seed);
+}
+
+__attribute__((export_name("kol_reset")))
+void wasm_kol_reset(void) {
+    kol_reset();
+}
+
+__attribute__((export_name("kol_tick")))
+int wasm_kol_tick(void) {
+    return kol_tick();
+}
+
+__attribute__((export_name("kol_chat_push")))
+int wasm_kol_chat_push(uint32_t text_ptr) {
+    return kol_chat_push(wasm_cptr(text_ptr));
+}
+
+__attribute__((export_name("kol_eff")))
+double wasm_kol_eff(void) {
+    return kol_eff();
+}
+
+__attribute__((export_name("kol_compl")))
+double wasm_kol_compl(void) {
+    return kol_compl();
+}
+
+__attribute__((export_name("kol_tail_json")))
+int wasm_kol_tail_json(uint32_t buf_ptr, int cap, int n) {
+    return kol_tail_json(wasm_ptr(buf_ptr), cap, n);
+}
+
+__attribute__((export_name("kol_alloc")))
+uint32_t wasm_kol_alloc(uint32_t size) {
+    void *ptr = kol_alloc((size_t)size);
+    return (uint32_t)(uintptr_t)ptr;
+}
+
+__attribute__((export_name("kol_free")))
+void wasm_kol_free(uint32_t ptr) {
+    kol_free((void *)(uintptr_t)ptr);
+}


### PR DESCRIPTION
## Summary
- add explicit WebAssembly export wrappers for the Kolibri C API
- expose allocation helpers and structured pointer conversions for wasm callers
- harden the wasm build script with source discovery, toolchain checks, and deterministic linker flags

## Testing
- `make kolibri_native`
- `make test_core`
- `bash wasm/build_wasm.sh` *(fails: clang (with wasm32-wasi target) is required)*

------
https://chatgpt.com/codex/tasks/task_e_68d13d7cc6548323abf09d302e52ca55