### PR TITLE
Expand multimodal ingestion and output capabilities

### DIFF
--- a/core/engine.c
+++ b/core/engine.c
@@ -20,6 +20,76 @@ static void init_dataset(KolEngine *engine) {
     engine->dataset.count = n;
 }
 
+static uint8_t encode_sample(double value) {
+    double normalized = (value + 1.0) * 0.5;
+    if (normalized < 0.0) {
+        normalized = 0.0;
+    }
+    if (normalized > 1.0) {
+        normalized = 1.0;
+    }
+    long scaled = lrint(normalized * 9.0);
+    if (scaled < 0) {
+        scaled = 0;
+    }
+    if (scaled > 9) {
+        scaled = 9;
+    }
+    return (uint8_t)scaled;
+}
+
+static size_t compute_digits(KolEngine *engine, uint8_t *buffer, size_t capacity) {
+    if (!engine || !buffer || capacity == 0 || !engine->current) {
+        if (buffer && capacity > 0) {
+            memset(buffer, 0, capacity);
+        }
+        return 0;
+    }
+    size_t limit = engine->dataset.count;
+    if (limit > capacity) {
+        limit = capacity;
+    }
+    for (size_t i = 0; i < limit; ++i) {
+        double pred = dsl_eval(engine->current, engine->dataset.xs[i]);
+        buffer[i] = encode_sample(pred);
+    }
+    if (limit < capacity) {
+        memset(buffer + limit, 0, capacity - limit);
+    }
+    return limit;
+}
+
+static void digits_to_text(const uint8_t *digits, size_t len, char *buf, size_t cap) {
+    static const char SYMBOLS[] = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,?!";
+    size_t symbol_count = sizeof(SYMBOLS) - 1;
+    if (!buf || cap == 0) {
+        return;
+    }
+    size_t pos = 0;
+    size_t i = 0;
+    while (i + 1 < len && pos + 1 < cap) {
+        unsigned int value = (unsigned int)digits[i] * 10u + (unsigned int)digits[i + 1];
+        buf[pos++] = SYMBOLS[value % symbol_count];
+        i += 2;
+    }
+    if (i < len && pos + 1 < cap) {
+        buf[pos++] = SYMBOLS[digits[i] % symbol_count];
+    }
+    if (pos >= cap) {
+        pos = cap - 1;
+    }
+    buf[pos] = '\0';
+}
+
+static void engine_refresh_output(KolEngine *engine) {
+    if (!engine) {
+        return;
+    }
+    size_t produced = compute_digits(engine, engine->last_digits, sizeof(engine->last_digits));
+    engine->last_digit_count = produced;
+    digits_to_text(engine->last_digits, produced, engine->last_text, sizeof(engine->last_text));
+}
+
 KolEngine *engine_create(uint8_t depth, uint32_t seed) {
     KolEngine *engine = (KolEngine *)calloc(1, sizeof(KolEngine));
     if (!engine) {
@@ -35,6 +105,10 @@ KolEngine *engine_create(uint8_t depth, uint32_t seed) {
     engine->current = dsl_rand(&rng_state, 3);
     engine->last = metrics_eval(engine->current, &engine->dataset);
     engine->step = 0;
+    memset(engine->last_digits, 0, sizeof(engine->last_digits));
+    engine->last_digit_count = 0;
+    engine->last_text[0] = '\0';
+    engine_refresh_output(engine);
     return engine;
 }
 
@@ -125,11 +199,25 @@ int engine_tick(KolEngine *engine, const KolEvent *in, KolOutput *out) {
     block.compl = engine->last.compl;
     block.ts = persist_timestamp();
     chain_append(&block);
+    engine_refresh_output(engine);
     if (out) {
         strncpy(out->formula, block.formula, sizeof(out->formula) - 1);
         out->formula[sizeof(out->formula) - 1] = '\0';
         out->metrics = engine->last;
         out->leader = vote.leader_id;
+        out->digit_count = engine->last_digit_count;
+        if (out->digit_count > sizeof(out->digits) / sizeof(out->digits[0])) {
+            out->digit_count = sizeof(out->digits) / sizeof(out->digits[0]);
+        }
+        if (out->digit_count > 0) {
+            memcpy(out->digits, engine->last_digits, out->digit_count);
+        }
+        if (out->digit_count < sizeof(out->digits) / sizeof(out->digits[0])) {
+            memset(out->digits + out->digit_count, 0,
+                   sizeof(out->digits) / sizeof(out->digits[0]) - out->digit_count);
+        }
+        strncpy(out->text, engine->last_text, sizeof(out->text) - 1);
+        out->text[sizeof(out->text) - 1] = '\0';
     }
     return 0;
 }
@@ -139,12 +227,112 @@ int engine_ingest_text(KolEngine *engine, const char *utf8, KolEvent *out_event)
     if (!out_event || !utf8) {
         return -1;
     }
+    uint8_t digits[sizeof(out_event->digits)];
     size_t len = 0;
-    while (utf8[len] && len < sizeof(out_event->digits)) {
-        unsigned char ch = (unsigned char)utf8[len];
-        out_event->digits[len] = (uint8_t)(ch % 10u);
+    size_t capacity = sizeof(digits) / sizeof(digits[0]);
+    while (utf8[len] && len < capacity) {
+        digits[len] = (uint8_t)(((unsigned char)utf8[len]) % 10u);
         ++len;
     }
-    out_event->length = len;
+    return engine_ingest_digits(engine, digits, len, out_event);
+}
+
+int engine_ingest_digits(KolEngine *engine, const uint8_t *digits, size_t len, KolEvent *out_event) {
+    (void)engine;
+    if (!digits || !out_event) {
+        return -1;
+    }
+    size_t capacity = sizeof(out_event->digits) / sizeof(out_event->digits[0]);
+    size_t count = len < capacity ? len : capacity;
+    memset(out_event->digits, 0, sizeof(out_event->digits));
+    for (size_t i = 0; i < count; ++i) {
+        out_event->digits[i] = (uint8_t)(digits[i] % 10u);
+    }
+    out_event->length = count;
     return 0;
+}
+
+int engine_ingest_bytes(KolEngine *engine, const uint8_t *bytes, size_t len, KolEvent *out_event) {
+    (void)engine;
+    if (!bytes || !out_event) {
+        return -1;
+    }
+    size_t capacity = sizeof(out_event->digits) / sizeof(out_event->digits[0]);
+    size_t idx = 0;
+    memset(out_event->digits, 0, sizeof(out_event->digits));
+    for (size_t i = 0; i < len && idx + 3 <= capacity; ++i) {
+        uint8_t value = bytes[i];
+        out_event->digits[idx++] = (uint8_t)((value / 100u) % 10u);
+        out_event->digits[idx++] = (uint8_t)((value / 10u) % 10u);
+        out_event->digits[idx++] = (uint8_t)(value % 10u);
+    }
+    out_event->length = idx;
+    return 0;
+}
+
+int engine_ingest_signal(KolEngine *engine, const float *samples, size_t len, KolEvent *out_event) {
+    (void)engine;
+    if (!samples || !out_event) {
+        return -1;
+    }
+    size_t capacity = sizeof(out_event->digits) / sizeof(out_event->digits[0]);
+    size_t count = len < capacity ? len : capacity;
+    memset(out_event->digits, 0, sizeof(out_event->digits));
+    for (size_t i = 0; i < count; ++i) {
+        double normalized = ((double)samples[i] + 1.0) * 0.5;
+        if (normalized < 0.0) {
+            normalized = 0.0;
+        }
+        if (normalized > 1.0) {
+            normalized = 1.0;
+        }
+        long scaled = lrint(normalized * 9.0);
+        if (scaled < 0) {
+            scaled = 0;
+        }
+        if (scaled > 9) {
+            scaled = 9;
+        }
+        out_event->digits[i] = (uint8_t)scaled;
+    }
+    out_event->length = count;
+    return 0;
+}
+
+int engine_render_digits(KolEngine *engine, uint8_t *digits, size_t max_len, size_t *out_len) {
+    if (!engine || !digits || max_len == 0) {
+        return -1;
+    }
+    if (engine->last_digit_count == 0 && engine->current) {
+        engine_refresh_output(engine);
+    }
+    size_t copy = engine->last_digit_count;
+    if (copy > max_len) {
+        copy = max_len;
+    }
+    memcpy(digits, engine->last_digits, copy);
+    if (out_len) {
+        *out_len = copy;
+    }
+    if (copy < max_len) {
+        memset(digits + copy, 0, max_len - copy);
+    }
+    return 0;
+}
+
+int engine_render_text(KolEngine *engine, char *buf, size_t cap) {
+    if (!engine || !buf || cap == 0) {
+        return -1;
+    }
+    if (engine->last_digit_count == 0 && engine->current) {
+        engine_refresh_output(engine);
+    }
+    size_t text_len = strlen(engine->last_text);
+    if (text_len >= cap) {
+        memcpy(buf, engine->last_text, cap - 1);
+        buf[cap - 1] = '\0';
+        return (int)(cap - 1);
+    }
+    memcpy(buf, engine->last_text, text_len + 1);
+    return (int)text_len;
 }

--- a/core/engine.h
+++ b/core/engine.h
@@ -1,6 +1,7 @@
 #ifndef KOLIBRI_ENGINE_H
 #define KOLIBRI_ENGINE_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "chain.h"
@@ -18,11 +19,19 @@ typedef struct {
     KolDataset dataset;
     double xs[32];
     double ys[32];
+    uint8_t last_digits[128];
+    size_t last_digit_count;
+    char last_text[128];
 } KolEngine;
 
 KolEngine *engine_create(uint8_t depth, uint32_t seed);
 void       engine_free(KolEngine *engine);
 int        engine_tick(KolEngine *engine, const KolEvent *in, KolOutput *out);
 int        engine_ingest_text(KolEngine *engine, const char *utf8, KolEvent *out_event);
+int        engine_ingest_digits(KolEngine *engine, const uint8_t *digits, size_t len, KolEvent *out_event);
+int        engine_ingest_bytes(KolEngine *engine, const uint8_t *bytes, size_t len, KolEvent *out_event);
+int        engine_ingest_signal(KolEngine *engine, const float *samples, size_t len, KolEvent *out_event);
+int        engine_render_digits(KolEngine *engine, uint8_t *digits, size_t max_len, size_t *out_len);
+int        engine_render_text(KolEngine *engine, char *buf, size_t cap);
 
 #endif

--- a/core/kolibri.c
+++ b/core/kolibri.c
@@ -10,14 +10,36 @@
 static KolEngine *g_engine = NULL;
 static KolEvent   g_event;
 static int        g_has_event = 0;
+static KolOutput  g_last_output;
+
+static void event_merge(KolEvent *dst, const KolEvent *src) {
+    if (!dst || !src || src->length == 0) {
+        return;
+    }
+    size_t capacity = sizeof(dst->digits) / sizeof(dst->digits[0]);
+    if (dst->length > capacity) {
+        dst->length = capacity;
+    }
+    size_t remain = capacity > dst->length ? capacity - dst->length : 0;
+    size_t to_copy = src->length < remain ? src->length : remain;
+    if (to_copy > 0) {
+        memcpy(dst->digits + dst->length, src->digits, to_copy);
+        dst->length += to_copy;
+    }
+}
 
 int kol_init(uint8_t depth, uint32_t seed) {
     kol_reset();
     g_engine = engine_create(depth, seed);
     g_has_event = 0;
+    memset(&g_last_output, 0, sizeof(g_last_output));
     if (!g_engine) {
         return -1;
     }
+    g_last_output.metrics = g_engine->last;
+    engine_render_digits(g_engine, g_last_output.digits, sizeof(g_last_output.digits),
+                         &g_last_output.digit_count);
+    engine_render_text(g_engine, g_last_output.text, sizeof(g_last_output.text));
     return 0;
 }
 
@@ -27,6 +49,8 @@ void kol_reset(void) {
         g_engine = NULL;
     }
     g_has_event = 0;
+    memset(&g_event, 0, sizeof(g_event));
+    memset(&g_last_output, 0, sizeof(g_last_output));
 }
 
 int kol_tick(void) {
@@ -34,7 +58,8 @@ int kol_tick(void) {
         return -1;
     }
     KolEvent *event_ptr = g_has_event ? &g_event : NULL;
-    int res = engine_tick(g_engine, event_ptr, NULL);
+    memset(&g_last_output, 0, sizeof(g_last_output));
+    int res = engine_tick(g_engine, event_ptr, &g_last_output);
     g_has_event = 0;
     return res;
 }
@@ -43,10 +68,17 @@ int kol_chat_push(const char *text) {
     if (!g_engine) {
         return -1;
     }
-    if (engine_ingest_text(g_engine, text, &g_event) != 0) {
+    KolEvent incoming;
+    memset(&incoming, 0, sizeof(incoming));
+    if (engine_ingest_text(g_engine, text, &incoming) != 0) {
         return -1;
     }
-    g_has_event = 1;
+    if (!g_has_event) {
+        g_event = incoming;
+        g_has_event = 1;
+    } else {
+        event_merge(&g_event, &incoming);
+    }
     return 0;
 }
 
@@ -62,6 +94,60 @@ double kol_compl(void) {
         return 0.0;
     }
     return g_engine->last.compl;
+}
+
+int kol_ingest_digits(const uint8_t *digits, size_t len) {
+    if (!g_engine) {
+        return -1;
+    }
+    KolEvent incoming;
+    memset(&incoming, 0, sizeof(incoming));
+    if (engine_ingest_digits(g_engine, digits, len, &incoming) != 0) {
+        return -1;
+    }
+    if (!g_has_event) {
+        g_event = incoming;
+        g_has_event = 1;
+    } else {
+        event_merge(&g_event, &incoming);
+    }
+    return 0;
+}
+
+int kol_ingest_bytes(const uint8_t *bytes, size_t len) {
+    if (!g_engine) {
+        return -1;
+    }
+    KolEvent incoming;
+    memset(&incoming, 0, sizeof(incoming));
+    if (engine_ingest_bytes(g_engine, bytes, len, &incoming) != 0) {
+        return -1;
+    }
+    if (!g_has_event) {
+        g_event = incoming;
+        g_has_event = 1;
+    } else {
+        event_merge(&g_event, &incoming);
+    }
+    return 0;
+}
+
+int kol_ingest_signal(const float *samples, size_t len) {
+    if (!g_engine) {
+        return -1;
+    }
+    KolEvent incoming;
+    memset(&incoming, 0, sizeof(incoming));
+    if (engine_ingest_signal(g_engine, samples, len, &incoming) != 0) {
+        return -1;
+    }
+    if (!g_has_event) {
+        g_event = incoming;
+        g_has_event = 1;
+    } else {
+        event_merge(&g_event, &incoming);
+    }
+    return 0;
 }
 
 static void hex_encode(const uint8_t *data, size_t len, char *out, size_t cap) {
@@ -121,6 +207,46 @@ int kol_tail_json(char *buf, int cap, int n) {
     offset += tail;
     free(blocks);
     return offset;
+}
+
+int kol_emit_digits(uint8_t *digits, size_t max_len, size_t *out_len) {
+    if (!g_engine || !digits || max_len == 0) {
+        return -1;
+    }
+    if (engine_render_digits(g_engine, g_last_output.digits, sizeof(g_last_output.digits),
+                             &g_last_output.digit_count) != 0) {
+        return -1;
+    }
+    size_t copy = g_last_output.digit_count;
+    if (copy > max_len) {
+        copy = max_len;
+    }
+    memcpy(digits, g_last_output.digits, copy);
+    if (out_len) {
+        *out_len = copy;
+    }
+    if (copy < max_len) {
+        memset(digits + copy, 0, max_len - copy);
+    }
+    return 0;
+}
+
+int kol_emit_text(char *buf, size_t cap) {
+    if (!g_engine || !buf || cap == 0) {
+        return -1;
+    }
+    int written = engine_render_text(g_engine, g_last_output.text, sizeof(g_last_output.text));
+    if (written < 0) {
+        return -1;
+    }
+    size_t text_len = strlen(g_last_output.text);
+    if (text_len >= cap) {
+        memcpy(buf, g_last_output.text, cap - 1);
+        buf[cap - 1] = '\0';
+        return (int)(cap - 1);
+    }
+    memcpy(buf, g_last_output.text, text_len + 1);
+    return (int)text_len;
 }
 
 void *kol_alloc(size_t size) {

--- a/core/kolibri.h
+++ b/core/kolibri.h
@@ -10,9 +10,14 @@ int    kol_init(uint8_t depth, uint32_t seed);
 void   kol_reset(void);
 int    kol_tick(void);
 int    kol_chat_push(const char *text);
+int    kol_ingest_digits(const uint8_t *digits, size_t len);
+int    kol_ingest_bytes(const uint8_t *bytes, size_t len);
+int    kol_ingest_signal(const float *samples, size_t len);
 double kol_eff(void);
 double kol_compl(void);
 int    kol_tail_json(char *buf, int cap, int n);
+int    kol_emit_digits(uint8_t *digits, size_t max_len, size_t *out_len);
+int    kol_emit_text(char *buf, size_t cap);
 void  *kol_alloc(size_t size);
 void   kol_free(void *ptr);
 

--- a/core/state.h
+++ b/core/state.h
@@ -23,6 +23,9 @@ typedef struct {
     char formula[256];
     KolMetrics metrics;
     uint8_t leader;
+    uint8_t digits[128];
+    size_t digit_count;
+    char text[128];
 } KolOutput;
 
 #endif

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "../core/kolibri.h"
 
@@ -11,6 +12,25 @@ int main(void) {
     kol_chat_push("kolibri");
     int tick_res = kol_tick();
     assert(tick_res == 0);
+    uint8_t seed_digits[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    assert(kol_ingest_digits(seed_digits, sizeof(seed_digits)) == 0);
+    const uint8_t bytes_payload[] = {0u, 127u, 255u, 64u};
+    assert(kol_ingest_bytes(bytes_payload, sizeof(bytes_payload)) == 0);
+    const float signal_payload[] = {0.0f, -1.0f, 1.0f, 0.25f, -0.25f};
+    assert(kol_ingest_signal(signal_payload,
+                             sizeof(signal_payload) / sizeof(signal_payload[0])) == 0);
+    assert(kol_tick() == 0);
+    uint8_t out_digits[128];
+    size_t  out_len = 0;
+    assert(kol_emit_digits(out_digits, sizeof(out_digits), &out_len) == 0);
+    assert(out_len > 0);
+    for (size_t i = 0; i < out_len; ++i) {
+        assert(out_digits[i] <= 9);
+    }
+    char text_buf[256];
+    int  text_len = kol_emit_text(text_buf, sizeof(text_buf));
+    assert(text_len >= 0);
+    assert((size_t)text_len < sizeof(text_buf));
     double eff = kol_eff();
     double compl = kol_compl();
     assert(eff >= 0.0 && eff <= 1.0);


### PR DESCRIPTION
## Summary
- add reusable helpers inside the C engine to quantise formula predictions into digit streams and derive symbolic text projections
- expose new ingestion routines for digit, byte and signal payloads together with digit/text emission helpers on the Kolibri public API
- expand KolOutput with cached multimodal data and extend the core test to validate the richer workflow

## Testing
- make test_core

------
https://chatgpt.com/codex/tasks/task_e_68d144798c108323b3c41eccd1ae2f46