### PR TITLE
Add language summary panel to UI

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -30,6 +30,10 @@ async function boot() {
   const effEl = document.getElementById('eff');
   const complEl = document.getElementById('compl');
   const outEl = document.getElementById('out');
+  const memoryEl = document.getElementById('memory');
+
+  const LANGUAGE_PREFIX = 'Kolibri запомнил:';
+  const LANGUAGE_DEFAULT_MESSAGE = 'Колибри пока молчит...';
 
   document.getElementById('send').addEventListener('click', () => {
     const txt = msgEl.value.trim();
@@ -39,12 +43,15 @@ async function boot() {
     wasm.kol_free(ptr);
     msgEl.value = '';
     refreshHud();
+    refreshTail();
+    refreshLanguageSummary();
   });
 
   document.getElementById('tick').addEventListener('click', () => {
     wasm.kol_tick();
     refreshHud();
     refreshTail();
+    refreshLanguageSummary();
   });
 
   function refreshHud() {
@@ -61,8 +68,35 @@ async function boot() {
     outEl.textContent = json;
   }
 
+  function refreshLanguageSummary() {
+    const cap = 512;
+    const ptr = wasm.kol_alloc(cap);
+    if (ptr === 0) {
+      memoryEl.textContent = LANGUAGE_DEFAULT_MESSAGE;
+      return;
+    }
+    const len = wasm.kol_language_generate(ptr, cap);
+    const text = len > 0 ? readString(instance, ptr, len) : '';
+    wasm.kol_free(ptr);
+
+    let display = text.trim();
+    if (len <= 0 || display.length === 0) {
+      memoryEl.textContent = LANGUAGE_DEFAULT_MESSAGE;
+      return;
+    }
+    if (display === LANGUAGE_DEFAULT_MESSAGE) {
+      memoryEl.textContent = LANGUAGE_DEFAULT_MESSAGE;
+      return;
+    }
+    if (display.startsWith(LANGUAGE_PREFIX)) {
+      display = display.slice(LANGUAGE_PREFIX.length).trim();
+    }
+    memoryEl.textContent = display.length > 0 ? display : LANGUAGE_DEFAULT_MESSAGE;
+  }
+
   refreshHud();
   refreshTail();
+  refreshLanguageSummary();
 
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./pwa/sw.js').catch(() => {});

--- a/ui/index.html
+++ b/ui/index.html
@@ -21,6 +21,8 @@
         <h2>Метрики</h2>
         <div class="metric">eff: <span id="eff">0.0000</span></div>
         <div class="metric">compl: <span id="compl">0.00</span></div>
+        <h2>Kolibri запомнил</h2>
+        <div id="memory" class="memory-output"></div>
         <h2>Цепочка</h2>
         <pre id="out"></pre>
       </section>

--- a/ui/style.css
+++ b/ui/style.css
@@ -69,3 +69,12 @@ pre {
 .metric {
   margin-bottom: 0.4rem;
 }
+
+.memory-output {
+  min-height: 3rem;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 8px;
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- add a new "Kolibri запомнил" panel to the UI layout
- style the memory output area for readability
- implement a WASM-backed language summary refresh with default handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17906c4f8832395b9c7153121f8b1