### PR TITLE
Add auto tick controls and async runner

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -30,21 +30,56 @@ async function boot() {
   const effEl = document.getElementById('eff');
   const complEl = document.getElementById('compl');
   const outEl = document.getElementById('out');
+  const answerEl = document.getElementById('answer');
+  const sendBtn = document.getElementById('send');
+  const tickBtn = document.getElementById('tick');
+  const autoCountEl = document.getElementById('autoCount');
+  const autoRunBtn = document.getElementById('autoRun');
+  const autoStopBtn = document.getElementById('autoStop');
 
-  document.getElementById('send').addEventListener('click', () => {
+  let autoAbort = false;
+  let autoPromise = null;
+
+  sendBtn.addEventListener('click', () => {
     const txt = msgEl.value.trim();
     if (!txt) return;
     const ptr = writeString(instance, txt);
     wasm.kol_chat_push(ptr);
     wasm.kol_free(ptr);
     msgEl.value = '';
-    refreshHud();
+    refreshAll();
   });
 
-  document.getElementById('tick').addEventListener('click', () => {
+  tickBtn.addEventListener('click', () => {
     wasm.kol_tick();
-    refreshHud();
-    refreshTail();
+    refreshAll();
+  });
+
+  autoRunBtn.addEventListener('click', async () => {
+    if (autoPromise) {
+      return;
+    }
+    const desired = parseInt(autoCountEl.value, 10);
+    if (!Number.isFinite(desired) || desired <= 0) {
+      return;
+    }
+    autoAbort = false;
+    setAutoRunning(true);
+    autoPromise = runAutoTicks(desired);
+    try {
+      await autoPromise;
+    } finally {
+      autoPromise = null;
+      setAutoRunning(false);
+      autoAbort = false;
+      refreshAll();
+    }
+  });
+
+  autoStopBtn.addEventListener('click', () => {
+    if (autoPromise) {
+      autoAbort = true;
+    }
   });
 
   function refreshHud() {
@@ -61,8 +96,49 @@ async function boot() {
     outEl.textContent = json;
   }
 
-  refreshHud();
-  refreshTail();
+  function refreshAnswer() {
+    if (!answerEl || typeof wasm.kol_emit_text !== 'function') {
+      return;
+    }
+    const cap = 4096;
+    const ptr = wasm.kol_alloc(cap);
+    if (!ptr) {
+      answerEl.textContent = '';
+      return;
+    }
+    const len = wasm.kol_emit_text(ptr, cap);
+    const text = len > 0 ? readString(instance, ptr, len) : '';
+    wasm.kol_free(ptr);
+    answerEl.textContent = text;
+  }
+
+  function refreshAll() {
+    refreshHud();
+    refreshTail();
+    refreshAnswer();
+  }
+
+  function setAutoRunning(running) {
+    sendBtn.disabled = running;
+    tickBtn.disabled = running;
+    autoRunBtn.disabled = running;
+    autoCountEl.disabled = running;
+    autoStopBtn.disabled = !running;
+  }
+
+  async function runAutoTicks(count) {
+    for (let i = 0; i < count; ++i) {
+      if (autoAbort) {
+        break;
+      }
+      wasm.kol_tick();
+      refreshAll();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  setAutoRunning(false);
+  refreshAll();
 
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./pwa/sw.js').catch(() => {});

--- a/ui/index.html
+++ b/ui/index.html
@@ -16,6 +16,14 @@
           <button id="send">Отправить</button>
           <button id="tick">Tick</button>
         </div>
+        <div class="controls">
+          <label class="auto-count">
+            Авто тики
+            <input id="autoCount" type="number" min="1" step="1" value="10" />
+          </label>
+          <button id="autoRun">Авто</button>
+          <button id="autoStop" disabled>Стоп</button>
+        </div>
       </section>
       <section class="panel status">
         <h2>Метрики</h2>
@@ -23,6 +31,8 @@
         <div class="metric">compl: <span id="compl">0.00</span></div>
         <h2>Цепочка</h2>
         <pre id="out"></pre>
+        <h2>Ответ</h2>
+        <pre id="answer"></pre>
       </section>
     </main>
     <script src="./app.js" type="module"></script>

--- a/ui/style.css
+++ b/ui/style.css
@@ -41,6 +41,29 @@ textarea {
   margin-top: 0.5rem;
 }
 
+.controls .auto-count {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.controls .auto-count input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.08);
+  color: #e6edf3;
+  box-sizing: border-box;
+}
+
+.controls .auto-count input:focus {
+  outline: none;
+  border-color: rgba(34, 211, 238, 0.6);
+}
+
 button {
   flex: 1;
   padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary
- add automatic tick count controls and answer panel to the UI
- implement async auto-tick loop with HUD refresh, stop control, and button locking
- style the numeric input to match the existing dark theme

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d178e65624832386c33c59c0b010fd