### PR TITLE
Improve WASM bootstrap error handling

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -9,12 +9,14 @@
   </head>
   <body>
     <main>
+      <div id="loading" class="loading" role="status">Загрузка Kolibri...</div>
+      <div id="error" class="error" role="alert" aria-live="assertive"></div>
       <section class="panel chat">
         <h1>Kolibri ИИ</h1>
-        <textarea id="msg" placeholder="Введите сообщение..."></textarea>
+        <textarea id="msg" placeholder="Введите сообщение..." disabled></textarea>
         <div class="controls">
-          <button id="send">Отправить</button>
-          <button id="tick">Tick</button>
+          <button id="send" disabled>Отправить</button>
+          <button id="tick" disabled>Tick</button>
         </div>
       </section>
       <section class="panel status">


### PR DESCRIPTION
## Summary
- add detailed error handling for loading and booting the Kolibri WASM module
- disable UI controls until Kolibri initialization completes and surface loader/error messages in the DOM
- introduce loading and error indicators in the HTML to improve user feedback

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d178e4cf748323b29858f5d0162aec