### PR TITLE
Persist UI state in localStorage

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -1,6 +1,17 @@
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
+const STORAGE_KEY = 'kolibri_ui_state_v1';
+const MAX_MESSAGES = 50;
+
+function createDefaultState() {
+  return {
+    messages: [],
+    tailJSON: '',
+    responseText: '',
+  };
+}
+
 async function loadWasm() {
   const response = await fetch('./kolibri.wasm');
   const buffer = await response.arrayBuffer();
@@ -21,6 +32,19 @@ function readString(wasm, ptr, len) {
   return decoder.decode(mem.subarray(0, len));
 }
 
+function storageAvailable(type) {
+  try {
+    const storage = window[type];
+    const testKey = '__kolibri_test__';
+    storage.setItem(testKey, testKey);
+    storage.removeItem(testKey);
+    return true;
+  } catch (err) {
+    console.warn('Хранилище недоступно или отключено', err);
+    return false;
+  }
+}
+
 async function boot() {
   const instance = await loadWasm();
   const wasm = instance.exports;
@@ -30,22 +54,110 @@ async function boot() {
   const effEl = document.getElementById('eff');
   const complEl = document.getElementById('compl');
   const outEl = document.getElementById('out');
+  const responseEl = document.getElementById('response');
+  const historyEl = document.getElementById('history');
+  const sendBtn = document.getElementById('send');
+  const tickBtn = document.getElementById('tick');
+  const clearBtn = document.getElementById('clear');
 
-  document.getElementById('send').addEventListener('click', () => {
+  let canPersist = storageAvailable('localStorage');
+  let state = createDefaultState();
+
+  if (canPersist) {
+    state = loadState();
+  }
+  applyStateToDOM();
+
+  sendBtn.addEventListener('click', () => {
     const txt = msgEl.value.trim();
     if (!txt) return;
     const ptr = writeString(instance, txt);
     wasm.kol_chat_push(ptr);
     wasm.kol_free(ptr);
     msgEl.value = '';
+    state.messages.push(txt);
+    if (state.messages.length > MAX_MESSAGES) {
+      state.messages.splice(0, state.messages.length - MAX_MESSAGES);
+    }
+    renderMessages();
+    persistState();
     refreshHud();
+    refreshTail();
+    refreshResponse();
   });
 
-  document.getElementById('tick').addEventListener('click', () => {
+  tickBtn.addEventListener('click', () => {
     wasm.kol_tick();
     refreshHud();
     refreshTail();
+    refreshResponse();
   });
+
+  clearBtn.addEventListener('click', () => {
+    state = createDefaultState();
+    applyStateToDOM();
+    if (canPersist) {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch (err) {
+        console.warn('Не удалось очистить localStorage', err);
+        canPersist = false;
+      }
+    }
+  });
+
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return createDefaultState();
+      }
+      const parsed = JSON.parse(raw);
+      return {
+        messages: Array.isArray(parsed.messages)
+          ? parsed.messages.slice(-MAX_MESSAGES)
+          : [],
+        tailJSON: typeof parsed.tailJSON === 'string' ? parsed.tailJSON : '',
+        responseText:
+          typeof parsed.responseText === 'string' ? parsed.responseText : '',
+      };
+    } catch (err) {
+      console.warn('Не удалось восстановить состояние UI', err);
+      return createDefaultState();
+    }
+  }
+
+  function persistState() {
+    if (!canPersist) {
+      return;
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (err) {
+      console.warn('Не удалось сохранить состояние UI', err);
+      canPersist = false;
+    }
+  }
+
+  function renderMessages() {
+    historyEl.innerHTML = '';
+    if (!state.messages.length) {
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    state.messages.forEach((message) => {
+      const li = document.createElement('li');
+      li.textContent = message;
+      fragment.appendChild(li);
+    });
+    historyEl.appendChild(fragment);
+  }
+
+  function applyStateToDOM() {
+    outEl.textContent = state.tailJSON || '';
+    responseEl.textContent = state.responseText || '';
+    renderMessages();
+  }
 
   function refreshHud() {
     effEl.textContent = wasm.kol_eff().toFixed(4);
@@ -55,14 +167,48 @@ async function boot() {
   function refreshTail() {
     const cap = 8192;
     const ptr = wasm.kol_alloc(cap);
-    const len = wasm.kol_tail_json(ptr, cap, 10);
-    const json = readString(instance, ptr, len > 0 ? len : 0);
-    wasm.kol_free(ptr);
-    outEl.textContent = json;
+    if (!ptr) {
+      return;
+    }
+    try {
+      const len = wasm.kol_tail_json(ptr, cap, 10);
+      if (len >= 0) {
+        const json = readString(instance, ptr, len > 0 ? len : 0);
+        outEl.textContent = json;
+        if (state.tailJSON !== json) {
+          state.tailJSON = json;
+          persistState();
+        }
+      }
+    } finally {
+      wasm.kol_free(ptr);
+    }
+  }
+
+  function refreshResponse() {
+    const cap = 4096;
+    const ptr = wasm.kol_alloc(cap);
+    if (!ptr) {
+      return;
+    }
+    try {
+      const len = wasm.kol_emit_text(ptr, cap);
+      if (len >= 0) {
+        const text = readString(instance, ptr, len > 0 ? len : 0);
+        responseEl.textContent = text;
+        if (state.responseText !== text) {
+          state.responseText = text;
+          persistState();
+        }
+      }
+    } finally {
+      wasm.kol_free(ptr);
+    }
   }
 
   refreshHud();
   refreshTail();
+  refreshResponse();
 
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./pwa/sw.js').catch(() => {});

--- a/ui/index.html
+++ b/ui/index.html
@@ -15,6 +15,11 @@
         <div class="controls">
           <button id="send">Отправить</button>
           <button id="tick">Tick</button>
+          <button id="clear">Очистить историю</button>
+        </div>
+        <div class="history">
+          <h2>История сообщений</h2>
+          <ul id="history"></ul>
         </div>
       </section>
       <section class="panel status">
@@ -23,6 +28,8 @@
         <div class="metric">compl: <span id="compl">0.00</span></div>
         <h2>Цепочка</h2>
         <pre id="out"></pre>
+        <h2>Ответ</h2>
+        <pre id="response"></pre>
       </section>
     </main>
     <script src="./app.js" type="module"></script>

--- a/ui/style.css
+++ b/ui/style.css
@@ -57,6 +57,30 @@ button:hover {
   transform: translateY(-1px);
 }
 
+.history {
+  margin-top: 1rem;
+}
+
+#history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+#history li {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  word-break: break-word;
+  font-size: 0.9rem;
+}
+
 pre {
   max-height: 320px;
   overflow: auto;


### PR DESCRIPTION
## Summary
- add persisted UI state for chat history, chain JSON, and response text using localStorage
- restore saved data on load and render message history with a new response view
- provide a clear history control and guard storage operations against quota errors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d178d4ff608323aa5c6874f6daad1e