### PR TITLE
Add runtime SLO reporting and alerts

### DIFF
--- a/tests/test_kolibri_x_pipeline.py
+++ b/tests/test_kolibri_x_pipeline.py
@@ -520,7 +520,7 @@ def test_runtime_orchestrator_end_to_end(
     assert cached_response.answer == response.answer
     assert cached_response.executions[0].output == response.executions[0].output
     journal_events = [entry.event for entry in runtime.journal.tail(5)]
-    assert "slo_snapshot" in journal_events
+    assert "slo_report" in journal_events
     all_events = [entry.event for entry in runtime.journal.entries()]
     assert "self_learning" in all_events
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -21,6 +21,8 @@
         <h2>Метрики</h2>
         <div class="metric">eff: <span id="eff">0.0000</span></div>
         <div class="metric">compl: <span id="compl">0.00</span></div>
+        <h2>SLO</h2>
+        <pre id="slo">нет данных</pre>
         <h2>Цепочка</h2>
         <pre id="out"></pre>
       </section>


### PR DESCRIPTION
## Summary
- extend the SLO tracker with JSON export, SLA thresholds and breach detection
- emit structured `slo_report` entries with stderr alerts from the runtime and surface them in the CLI and PWA
- update pipeline tests to expect the new SLO report event

## Testing
- pytest tests/test_kolibri_x_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d158c43924832393ef281520ff8f00