### PR TITLE
Add knowledge graph embedding cache with notifications

### DIFF
--- a/tests/test_kolibri_x_pipeline.py
+++ b/tests/test_kolibri_x_pipeline.py
@@ -5,7 +5,7 @@ import json
 from datetime import datetime, timedelta, timezone
 import sys
 from pathlib import Path
-from typing import Mapping
+from typing import Dict, List, Mapping
 
 import pytest
 
@@ -155,6 +155,30 @@ def test_rag_pipeline_returns_supported_answer(knowledge_graph: KnowledgeGraph) 
     assert answer["verification"]["status"] in {"ok", "partial", "conflict"}
     assert "Answering" in answer["summary"]
     assert reasoning.steps(), "reasoning log should not be empty"
+
+
+def test_rag_pipeline_reuses_cached_embeddings(knowledge_graph: KnowledgeGraph) -> None:
+    class CountingEncoder(TextEncoder):
+        def __init__(self, dim: int = 16) -> None:
+            super().__init__(dim=dim)
+            self.calls: Dict[str, int] = {}
+
+        def encode(self, text: str) -> List[float]:
+            self.calls[text] = self.calls.get(text, 0) + 1
+            return super().encode(text)
+
+    encoder = CountingEncoder(dim=16)
+    pipeline = RAGPipeline(knowledge_graph, encoder=encoder)
+
+    node_texts = [node.text for node in knowledge_graph.nodes() if node.text]
+    for text in node_texts:
+        assert encoder.calls.get(text, 0) == 1
+
+    pipeline.retrieve("Explain autonomy", top_k=2)
+    pipeline.retrieve("Explain autonomy", top_k=2)
+
+    for text in node_texts:
+        assert encoder.calls.get(text, 0) == 1
 
 
 def test_graph_hybrid_memory_and_verification(knowledge_graph: KnowledgeGraph) -> None:


### PR DESCRIPTION
## Summary
- add listener hooks to the knowledge graph so components can react to node lifecycle changes
- cache and warm node embeddings inside the RAG pipeline using the graph notifications
- cover the caching behaviour with a test that ensures repeated retrievals reuse cached encodings

## Testing
- pytest tests/test_kolibri_x_pipeline.py::test_rag_pipeline_reuses_cached_embeddings

------
https://chatgpt.com/codex/tasks/task_e_68d165e207d48323bb378bb8b86b111e