### PR TITLE
Fix unmatched braces in engine module

### DIFF
--- a/core/engine.c
+++ b/core/engine.c
@@ -113,7 +113,7 @@ static size_t extract_memory_keywords(const char *summary, char words[][64], siz
         ptr = stop;
     }
     return count;
-
+}
 
 static void engine_update_stats(KolEngine *engine) {
     if (!engine) {
@@ -142,6 +142,7 @@ static void engine_update_stats(KolEngine *engine) {
     engine->dataset_mean = sum / (double)n;
     engine->dataset_min = minv;
     engine->dataset_max = maxv;
+}
 
 typedef struct {
     uint32_t codepoint;


### PR DESCRIPTION
## Summary
- add the missing closing brace to extract_memory_keywords so helper functions remain at file scope
- ensure engine_update_stats ends cleanly to avoid nested function compilation errors

## Testing
- make test_core

------
https://chatgpt.com/codex/tasks/task_e_68d1a7b0e818832385a4f6106f8c878d